### PR TITLE
Fixing overlap of banner subtitle with sidebar

### DIFF
--- a/http/banner.css
+++ b/http/banner.css
@@ -42,7 +42,7 @@
     font-size: 15px;
     position: relative;
     top: -10px;
-    z-index: 999;
+    z-index: 29;
     color: #fff;
 }
 


### PR DESCRIPTION
In narrow view frames the Subtitle would be displayed over the sidebar.
z-index changed to 29 to be one lower than the sidebar: https://github.com/frhun/elixir/blob/3e69f7ddb1f9d58bb348ff34045f97942e0acf7e/http/style.css#L910