### PR TITLE
Fix C string literals

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -96,7 +96,7 @@ tokenize_file()
 
     git cat-file blob $ref 2>/dev/null |
     tr '\n' '\1' |
-    perl -pe 's%((/\*.*?\*/|//.*?\001|"(\\.|.)*?"|# *include *<.*?>|\W)+)(\w+)?%\1\n\4\n%g' |
+    perl -pe 's%((/\*.*?\*/|//.*?\001|[^'"'"']"(\\.|.)*?"|# *include *<.*?>|\W)+)(\w+)?%\1\n\4\n%g' |
     head -n -1
 }
 


### PR DESCRIPTION
This stops the tokenizer from treating double quotes within single quotes (i.e `'"'`) as the start of a string literal. It looks a bit messy because of the shell quote escaping but it's actually just adding `[^']`.

Fixes #40 