### PR TITLE
Parse the tag levels when applicable

### DIFF
--- a/query.py
+++ b/query.py
@@ -52,7 +52,15 @@ def query (cmd, *args):
 
         for line in scriptLines ('list-tags', '-h'):
             decoded_line = decode(line)
-            topmenu, submenu, tag = decoded_line.split(' ')
+            len_split = len(decoded_line.split(' '))
+            topmenu, submenu = 'UNKNOWN', 'UNKNOWN'
+            if (len_split == 1):
+                tag = decoded_line
+            if (len_split == 2):
+                submenu, tag = decoded_line.split(' ')
+            if (len_split == 3):
+                topmenu, submenu, tag = decoded_line.split(' ')
+
             if db.vers.exists (tag):
                 if topmenu not in versions:
                     versions[topmenu] = OrderedDict()


### PR DESCRIPTION
This patch fixes the error when the query on the tagging
expects 3 levels (v3 v3.1 v3.1-rc0) but gets only one level
from the `script.sh list-tags -h`

This results in the following error:

```
...
/home/naveen/workspace/elixir/query.py in query(cmd='versions', *args=())
     53         for line in scriptLines ('list-tags', '-h'):
     54             decoded_line = decode(line)
=>   55             topmenu, submenu, tag = decoded_line.split(' ')
     56             if db.vers.exists (tag):
     57                 if topmenu not in versions:
topmenu undefined, submenu undefined, tag undefined, decoded_line = 'Tag_V1', \
decoded_line.split = <built-in method split of str object>
...
```

Fix the issue by processing the menu levels when applicable.

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>