### PR TITLE
query: warn user if v1.2.34-rc5 style tagging not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ new project:
 Now, go back to the Elixir sources and test that tags are correctly
 extracted:
 
-    ./script.sh list-tags
+    ./script.sh list-tags -h
 
 Depending on how you want to show the available versions on the Elixir pages,
 you may have to apply substitutions to each tag string, for example to add
@@ -332,7 +332,8 @@ Note that this third entry must correspond to the exact
 name of the tag in git.
 
 If the default behavior is not what you want, you will have
-to customize the `list_tags_h` function.
+to customize the `list_tags_h` function. If the above format
+is not found in the project, a warning is shown.
 
 You should also make sure that Elixir properly identifies
 the most recent versions:

--- a/query.py
+++ b/query.py
@@ -53,7 +53,7 @@ def query (cmd, *args):
         for line in scriptLines ('list-tags', '-h'):
             taginfo = decode(line).split(' ')
             num = len(taginfo)
-            topmenu, submenu = 'FIXME', 'FIXME'
+            topmenu, submenu, tag = 'FIXME', 'FIXME', 'FIXME'
 
             if (num == 1):
                 tag, = taginfo

--- a/script.sh
+++ b/script.sh
@@ -49,9 +49,16 @@ list_tags()
 
 list_tags_h()
 {
-    echo "$tags" |
-    tac |
-    sed -r 's/^(v[0-9]*)\.([0-9]*)(.*)$/\1 \1.\2 \1.\2\3/'
+    # Check for strict tag format. If not found, warn user.
+    tag_list=`echo "$tags" | tac | sed -nr 's/(^v[0-9]*)\.([0-9]*)(.*)$/\1 \1.\2 \1.\2\3/p'`
+    if [ -z $tag_list ]; then
+	    tag_list=`echo "$tags" | tac`
+	    show_warn=1
+    fi
+    echo "$tag_list"
+    if [ $show_warn = 1 ]; then
+	    echo "\nWarning: v1.2.34-rc5 style tagging not found, using fallback hierarchy"
+    fi
 }
 
 get_latest()


### PR DESCRIPTION
Display a warning in `list-tags -h` if the standard tagging
format that is expected is not found.

Update documentation and initialize `tag` variable in the query.py
to avoid warnings.

Signed-off-by: Naveen Kaje <naveen.kaje@juul.com>