### PR TITLE
Fixed path dependency in lib.py

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -15,15 +15,6 @@ def build_query(env, project):
     import query
     return query.query
 
-def call_query(query, *args):
-    cwd = os.getcwd()
-    os.chdir(ELIXIR_DIR)
-    ret = query(*args)
-    os.chdir(cwd)
-
-    return ret
-
-
 class IdentResource:
     def on_get(self, req, resp, project, ident):
         query = build_query(req.env, project)
@@ -33,9 +24,9 @@ class IdentResource:
             raise falcon.HTTPMissingParam('version')
         
         if version == 'latest':
-            version = call_query(query, 'latest')
+            version = query('latest')
 
-        symbol_definitions, symbol_references = call_query(query, 'ident', version, ident)
+        symbol_definitions, symbol_references = query('ident', version, ident)
         if len(symbol_definitions) or len(symbol_references):
             resp.body = json.dumps(
                 {

--- a/http/web.py
+++ b/http/web.py
@@ -106,18 +106,10 @@ projects.sort()
 
 import sys
 sys.path = [ sys.path[0] + '/..' ] + sys.path
-import query
-
-def call_query(*args):
-    cwd = os.getcwd()
-    os.chdir('..')
-    ret = query.query(*args)
-    os.chdir(cwd)
-
-    return ret
+from query import query
 
 if version == 'latest':
-    tag = call_query('latest')
+    tag = query('latest')
 else:
     tag = version
 
@@ -132,7 +124,7 @@ data = {
     'breadcrumb': '<a class="project" href="'+version+'/source">/</a>'
 }
 
-versions = call_query('versions')
+versions = query('versions')
 
 v = ''
 b = 1
@@ -175,12 +167,12 @@ if mode == 'source':
 
     lines = ['null - -']
 
-    type = call_query('type', tag, path)
+    type = query('type', tag, path)
     if len(type) > 0:
         if type == 'tree':
-            lines += call_query('dir', tag, path)
+            lines += query('dir', tag, path)
         elif type == 'blob':
-            code = call_query('file', tag, path)
+            code = query('file', tag, path)
     else:
         print('<div class="lxrerror"><h2>This file does not exist.</h2></div>')
         status = 404
@@ -276,7 +268,7 @@ if mode == 'source':
 elif mode == 'ident':
     data['title'] = project.capitalize()+' source code: '+ident+' identifier ('+tag+') - Bootlin'
 
-    symbol_definitions, symbol_references = call_query('ident', tag, ident)
+    symbol_definitions, symbol_references = query('ident', tag, ident)
 
     print('<div class="lxrident">')
     if len(symbol_definitions):

--- a/lib.py
+++ b/lib.py
@@ -20,8 +20,10 @@
 
 import subprocess, os
 
+CURRNET_DIR = os.path.dirname(os.path.abspath(__file__))
+
 def script(*args):
-    args = ('./script.sh',) + args
+    args = (os.path.join(CURRNET_DIR, 'script.sh'),) + args
     # subprocess.run was introduced in Python 3.5
     # fall back to subprocess.check_output if it's not available
     if hasattr(subprocess, 'run'):


### PR DESCRIPTION
I'm starting to fix the code duplication between api.py and web.py.
This PR removes the necessity of a call_quey function by fixing a path dependency in lib.py.