### PR TITLE
README: include URL for Linux sublevel tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,13 @@ And then run `source /etc/profile`.
 
 ### Clone Kernel source code
 
-```
-git clone https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git /path/elixir-data/linux/repo/
-```
+Run one of the following, depending on whether or not you want `SUBLEVEL`
+(X.Y.Z) tags:
+
+* `git clone https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git /path/elixir-data/linux/repo/`
+  * Has only X.Y and X.Y-rcZ tags
+* `git clone git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git /path/elixir-data/linux/repo/`
+  * Has X.Y.Z tags
 
 ### First Test
 
@@ -382,7 +386,7 @@ The response body is of the following structure:
 {
     "definitions":
         [{"path": "commands/loadb.c", "line": 71, "type": "variable"}, ...],
-    "references": 
+    "references":
         [{"path": "arch/arm/boards/cm-fx6/board.c", "line": "64,64,71,72,75", "type": null}, ...]
 }
 ```


### PR DESCRIPTION
The Linux-kernel GitHub repo referenced in README doesn't have tags for sublevel (X.Y.Z) releases, unlike the master Bootlin Elixir site.  This confused me while trying to set up a local development instance.  This PR adds the master repo that does have the sublevel tags to the README.  I got the repo URL from <https://config9.com/linux/linux-kernel-how-to-obtain-a-particular-version-right-upto-sublevel/>.

Thank you for considering this PR!