### PR TITLE
Added API tests

### DIFF
--- a/t/100-basic.t
+++ b/t/100-basic.t
@@ -113,10 +113,6 @@ run_produces_ok('file query (existent), .h',
     [qr{i2c-core\.h}, qr{\bWe\b}],
     MUST_SUCCEED);
 
-# Test the api using pytest. Prints the test results.
-
-run_produces_ok('api pytest suite', ["pytest", "-v"], [], MUST_SUCCEED, 1);
-
 #system('bash'); # Uncomment this if you want to interact with the test repo
 
 done_testing;

--- a/t/100-basic.t
+++ b/t/100-basic.t
@@ -113,6 +113,10 @@ run_produces_ok('file query (existent), .h',
     [qr{i2c-core\.h}, qr{\bWe\b}],
     MUST_SUCCEED);
 
+# Test the api using pytest. Prints the test results.
+
+run_produces_ok('api pytest suite', ["pytest", "-v"], [], MUST_SUCCEED, 1);
+
 #system('bash'); # Uncomment this if you want to interact with the test repo
 
 done_testing;

--- a/t/200-api.t
+++ b/t/200-api.t
@@ -1,0 +1,36 @@
+#!/usr/bin/env perl
+# 200-api.t: Test elixir's REST api against the files in tree/ .
+#
+# Copyright (c) 2020 Tamir Carmeli, <carmeli.tamir@gmail.com>.
+#
+# Elixir is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Elixir is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# # You should have received a copy of the GNU Affero General Public License
+# along with Elixir.  If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file uses core Perl modules only.
+
+use FindBin '$Bin';
+use lib $Bin;
+
+use Test::More;
+
+use TestEnvironment;
+use TestHelpers;
+
+my $tenv = TestEnvironment->new;
+$tenv->build_repo(sibling_abs_path('tree'))->build_db->update_env;
+
+# Test the api using pytest. Prints the test results
+run_produces_ok('api pytest suite', ["pytest", "-v"], [], MUST_SUCCEED, 1);
+
+done_testing;

--- a/t/TestHelpers.pm
+++ b/t/TestHelpers.pm
@@ -145,17 +145,18 @@ Run a program and check whether it produces expected output.
 Usage:
 
     run_produces_ok($desc, \@program_and_args, \@expected_regexes,
-                    <optional> $mustSucceed)
+                    <optional> $mustSucceed, <optional> $printOutput)
 
 The test passes if each regex in C<@expected_regexes> matches at least one
 line in the output of C<@program_and_args>, and if each C<< { not => regex } >>
 in C<@expected_regexes> is NOT found in that output.
 If C<$mustSucceed> is true, also tests for exit status 0 and empty stderr.
+If C<$printOutput> is true, prints the output of C<@program_and_args>.
 
 =cut
 
 sub run_produces_ok {
-    my ($desc, $lrProgram, $lrRegexes, $mustSucceed) = @_;
+    my ($desc, $lrProgram, $lrRegexes, $mustSucceed, $printOutput) = @_;
 
     # Run program and capture stdout and stderr
     my ($in , $out, $err);      # Filehandles
@@ -186,6 +187,10 @@ sub run_produces_ok {
 
     waitpid $pid, 0;
     my $exit_status = $? >> 8;
+
+    if ($printOutput) {
+        diag "@outlines";
+    }
 
     # Basic checks
     if($mustSucceed) {

--- a/t/api_test.py
+++ b/t/api_test.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+from falcon import testing
+
+api_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..','api'))
+sys.path.insert(0, api_dir)
+
+from api import create_ident_getter
+
+class APITest(testing.TestCase):
+    def setUp(self):
+        super(APITest, self).setUp()
+
+        self.app = create_ident_getter()
+
+class TestMyApp(APITest):
+    def test_identifier_not_found(self):
+        result = self.simulate_get('/ident/tree/SOME_NONEXISTENT_IDENTIFIER', query_string="version=latest")
+
+        self.assertEqual(result.status_code, 200)
+        self.assertEqual(result.json, {'definitions': [], 'references':[]})


### PR DESCRIPTION
Added a pytest setup for api.py, currently with just one basic test - after this is approved I'll add some more.

Since the API is based on the Pythonic falcon, and falcon includes it's own testing library, the test is written in Python - but is executed from the existing Perl tests which set up the environment to get Elixir working.

The PR is verified on the CI of my Elixir fork, [link](https://travis-ci.com/github/carmeli-tamir/elixir/builds/154313598). @michaelopdenacker Do you need assistance setting it up?

@cxw42 appreciate your feedback.