### PR TITLE
Regularize whitespace; add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# see https://editorconfig.org for the format of this file
+root = true
+
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ http/images
 http/*.html
 http/favicon.ico
 http/robots.txt
+
+# Editor and other backup files
+*.swp
+*~
+~*

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ server.document-root = server_root + "/elixir/http"
 url.redirect = ( "^/$" => "/linux/latest/source" )
 url.rewrite  = ( "^/.*/(source|ident|search)" =>  "/web.py/$1")
 setenv.add-environment = ( "PYTHONIOENCODING" => "utf-8",
-	"LXR_PROJ_DIR" => "/path/to/elixir-data" )
+    "LXR_PROJ_DIR" => "/path/to/elixir-data" )
 ```
 
 ### Using a cache to improve performance

--- a/http/banner.css
+++ b/http/banner.css
@@ -23,10 +23,10 @@
     filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#ededed', GradientType=0 );
 }
 .message-banner-desktop p.title {
-	font-size: 14px;
-	margin: 0;
-	margin-top: 5px;
-	margin-bottom: 8px;
+    font-size: 14px;
+    margin: 0;
+    margin-top: 5px;
+    margin-bottom: 8px;
 }
 .message-banner-desktop .subtitle {
     width: 210px;
@@ -37,46 +37,46 @@
 }
 
 .message-banner-mobile {
-	display: none;
-	text-align: center;
-	position: absolute;
-	background: #fe003e;
-	color: #fff;
-	font-family: Arial;
-	-webkit-transform:rotate(-90deg);
-	-moz-transform:rotate(-90deg);
-	-o-transform: rotate(-90deg);
-	-ms-transform:rotate(-90deg);
-	transform: rotate(-90deg);
-	left: -58px;
-	bottom: 58px;
-	padding: 5px;
+    display: none;
+    text-align: center;
+    position: absolute;
+    background: #fe003e;
+    color: #fff;
+    font-family: Arial;
+    -webkit-transform:rotate(-90deg);
+    -moz-transform:rotate(-90deg);
+    -o-transform: rotate(-90deg);
+    -ms-transform:rotate(-90deg);
+    transform: rotate(-90deg);
+    left: -58px;
+    bottom: 58px;
+    padding: 5px;
 }
 .message-banner-mobile .title {
-	margin: 0;
-	font-size: 25px;
+    margin: 0;
+    font-size: 25px;
 }
 .message-banner-mobile .subtitle {
-	margin: 0;
-	font-size: 11px;
+    margin: 0;
+    font-size: 11px;
 }
 .message-banner-mobile:hover {
-	background: #f37b30;
+    background: #f37b30;
 }
 .message-banner-mobile .message-link,
 .message-banner-desktop .message-link {
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	top: 0;
-	left: 0;
-	z-index: 99999;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    z-index: 99999;
 }
 header.header {
     position: relative !important;
 }
 header.header h2 {
-	margin-bottom: 3rem;
+    margin-bottom: 3rem;
 }
 .icon-googleplus:before,
 .icon-mastodon:before {
@@ -84,26 +84,26 @@ header.header h2 {
     left: 3px;
 }
 .select-projects {
-	background-position: bottom 0.15em right 0.3em;
-	width: 100%;
+    background-position: bottom 0.15em right 0.3em;
+    width: 100%;
 }
 
 @media screen and (max-width: 600px) {
-	.message-banner-desktop {
-		display: none;
-	}
-	.message-banner-mobile {
-		display: block;
-	}
+    .message-banner-desktop {
+        display: none;
+    }
+    .message-banner-mobile {
+        display: block;
+    }
 }
 @media screen and (max-width: 400px) {
-	.message-banner-mobile {
-	    bottom: 50px;
-	}
-	.message-banner-mobile .title {
-	    font-size: 20px;
-	}
-	.message-banner-mobile .subtitle {
-	    font-size: 9.5px;
-	}
+    .message-banner-mobile {
+        bottom: 50px;
+    }
+    .message-banner-mobile .title {
+        font-size: 20px;
+    }
+    .message-banner-mobile .subtitle {
+        font-size: 9.5px;
+    }
 }

--- a/script.sh
+++ b/script.sh
@@ -105,13 +105,13 @@ list_blobs()
     v=`echo $opt2 | version_rev`
 
     if [ "$opt1" = '-p' ]; then
-	# "path" option: return blob hash and full path
+        # "path" option: return blob hash and full path
         format='\1 \2'
     elif [ "$opt1" = '-f' ]; then
-	# "file" option: return blob hash and file name (without its path)
+        # "file" option: return blob hash and file name (without its path)
         format='\1 \4'
     else
-	# default option: return only blob hash
+        # default option: return only blob hash
         format='\1'
         v=`echo $opt1 | version_rev`
     fi

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,37 +1,37 @@
 <header class="header">
-        <div class="message-banner-mobile">
-             <p class="title">Training sessions</p>
-             <p class="subtitle">Kernel and Embedded Linux</p>
-             <a class="message-link" target="_blank" href="https://bootlin.com/training/sessions/"></a>
-        </div>
-        <div class="message-banner-desktop">
-             <p class="title">Next training sessions</p>
-             <div class="subtitle">Linux Kernel: March 16-20</div>
-             <div class="subtitle">Embedded Linux: May 11-15</div>
-             <div class="subtitle">and on-site sessions</div>
-             <a class="message-link" target="_blank" href="https://bootlin.com/training/sessions/"></a>
-        </div>
-	<h1>
-		<object data="/images/bootlin-logo-white.svg" type="image/svg+xml">
-		<!-- If the browser doesn't support SVG  -->
-		<img src="/images/bootlin-logo-white.png" alt="Bootlin logo" />
-		</object>
-	</h1>
-	<h2>Elixir Cross Referencer</h2>
-	<nav>
-		<ul class="nav-links">
-			<li><a href="https://bootlin.com/">Home</a></li>
-			<li><a href="https://bootlin.com/engineering/">Engineering</a></li>
-			<li><a href="https://bootlin.com/training/">Training</a></li>
-			<li><a href="https://bootlin.com/docs/">Docs</a></li>
-			<li><a href="https://bootlin.com/community/">Community</a></li>
-			<li><a href="https://bootlin.com/company/">Company</a></li>
-		</ul>
-		<ul class="social-icons">
-			<li><a target="_blank" class="icon-twitter" href="http://twitter.com/bootlincom">twitter</a></li>
-			<li><a target="_blank" class="icon-mastodon" href="https://fosstodon.org/@bootlin">mastodon</a></li>
-			<li><a target="_blank" class="icon-linkedin" href="https://www.linkedin.com/groups/4501089">linkedin</a></li>
-			<li><a target="_blank" class="icon-github" href="https://github.com/bootlin">github</a></li>
-		</ul>
-	</nav>
+    <div class="message-banner-mobile">
+         <p class="title">Training sessions</p>
+         <p class="subtitle">Kernel and Embedded Linux</p>
+         <a class="message-link" target="_blank" href="https://bootlin.com/training/sessions/"></a>
+    </div>
+    <div class="message-banner-desktop">
+         <p class="title">Next training sessions</p>
+         <div class="subtitle">Linux Kernel: March 16-20</div>
+         <div class="subtitle">Embedded Linux: May 11-15</div>
+         <div class="subtitle">and on-site sessions</div>
+         <a class="message-link" target="_blank" href="https://bootlin.com/training/sessions/"></a>
+    </div>
+    <h1>
+        <object data="/images/bootlin-logo-white.svg" type="image/svg+xml">
+        <!-- If the browser doesn't support SVG  -->
+        <img src="/images/bootlin-logo-white.png" alt="Bootlin logo" />
+        </object>
+    </h1>
+    <h2>Elixir Cross Referencer</h2>
+    <nav>
+        <ul class="nav-links">
+            <li><a href="https://bootlin.com/">Home</a></li>
+            <li><a href="https://bootlin.com/engineering/">Engineering</a></li>
+            <li><a href="https://bootlin.com/training/">Training</a></li>
+            <li><a href="https://bootlin.com/docs/">Docs</a></li>
+            <li><a href="https://bootlin.com/community/">Community</a></li>
+            <li><a href="https://bootlin.com/company/">Company</a></li>
+        </ul>
+        <ul class="social-icons">
+            <li><a target="_blank" class="icon-twitter" href="http://twitter.com/bootlincom">twitter</a></li>
+            <li><a target="_blank" class="icon-mastodon" href="https://fosstodon.org/@bootlin">mastodon</a></li>
+            <li><a target="_blank" class="icon-linkedin" href="https://www.linkedin.com/groups/4501089">linkedin</a></li>
+            <li><a target="_blank" class="icon-github" href="https://github.com/bootlin">github</a></li>
+        </ul>
+    </nav>
 </header>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,64 +1,64 @@
 <!doctype html>
 <html class="no-js">
-	<head>
-		<meta charset="utf-8">
-		<meta http-equiv="x-ua-compatible" content="ie=edge">
-		<title>{{title}}</title>
-		<meta name="description" content="Elixir Cross Referencer">
-		<meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1" />
-		<link rel="stylesheet" href="/style.css?v=3">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <title>{{title}}</title>
+        <meta name="description" content="Elixir Cross Referencer">
+        <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1" />
+        <link rel="stylesheet" href="/style.css?v=3">
         <link rel="stylesheet" href="/banner.css">
-		<base href="{{baseurl}}"/>
-		<script>document.documentElement.className = 'js'</script>
-	</head>
-	<body>
-		<!--[if lte IE 9]>
-				<p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience and security.</p>
-		<![endif]-->
-		<div class="wrapper">
-			{% include 'header.html' %}
-			<header class="topbar">
-				<div class="breadcrumb">
-					<a href="{{version}}/{{url}}#menu" class="open-menu icon-menu screenreader" title="Open Menu">Open Menu</a>
-					{{breadcrumb}}
-				</div>
-				<div class="search">
-					<form method="post" action="{{version}}/ident">
-						<input placeholder="Search Identifier" type="text" name="i" value="{{ident}}"/>
-						<button class="icon-search"><span class="screenreader">Go get it</span></button>
-					</form>
-				</div>
-			</header>
-			<main>
-				<div class="workspace">
-					{{main}}
-				</div>
-				<aside class="sidebar" id="menu">
-				        <select class="select-projects" onchange="window.location.href=this.value">
-				        {%- for p in projects %}
-					        <option{% if p == project %} selected{% endif %} value="/{{p}}/latest/source">{{p}}</option>
-				        {%- endfor %}
-				        </select>
-					<nav>
-						<h3 class="screenreader">Projects</h3>
-						<ul class="projects">
-							{%- for p in projects %}
-							<li{% if p == project %} class="active"{% endif %}><a href="/{{p}}/latest/source">{{p}}</a></li>
-							{%- endfor %}
-						</ul>
-						<h3 class="screenreader">Versions</h3>
-						<ul class="versions">
-							{{versions}}
-						</ul>
-					</nav>
-				</aside>
-			</main>
-			<footer class="footer">
-				<span class="version"><a href="{{version}}/source">{{project}}</a> <em class="icon-tag">{{tag}}</em></span>
-				<a title="Go to top of the page" class="go-top icon-up screenreader" href="{{version}}/{{url}}#">Top</a>
-				<span class="poweredby">powered by <a target="_blank" href="https://github.com/bootlin/elixir">Elixir 1.0</a></span>
-			</footer>
-		</div>
-		<script src="/script.js?v=3"></script>
-	</body>
+        <base href="{{baseurl}}"/>
+        <script>document.documentElement.className = 'js'</script>
+    </head>
+    <body>
+        <!--[if lte IE 9]>
+                <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience and security.</p>
+        <![endif]-->
+        <div class="wrapper">
+            {% include 'header.html' %}
+            <header class="topbar">
+                <div class="breadcrumb">
+                    <a href="{{version}}/{{url}}#menu" class="open-menu icon-menu screenreader" title="Open Menu">Open Menu</a>
+                    {{breadcrumb}}
+                </div>
+                <div class="search">
+                    <form method="post" action="{{version}}/ident">
+                        <input placeholder="Search Identifier" type="text" name="i" value="{{ident}}"/>
+                        <button class="icon-search"><span class="screenreader">Go get it</span></button>
+                    </form>
+                </div>
+            </header>
+            <main>
+                <div class="workspace">
+                    {{main}}
+                </div>
+                <aside class="sidebar" id="menu">
+                    <select class="select-projects" onchange="window.location.href=this.value">
+                        {%- for p in projects %}
+                            <option{% if p == project %} selected{% endif %} value="/{{p}}/latest/source">{{p}}</option>
+                        {%- endfor %}
+                    </select>
+                    <nav>
+                        <h3 class="screenreader">Projects</h3>
+                        <ul class="projects">
+                            {%- for p in projects %}
+                            <li{% if p == project %} class="active"{% endif %}><a href="/{{p}}/latest/source">{{p}}</a></li>
+                            {%- endfor %}
+                        </ul>
+                        <h3 class="screenreader">Versions</h3>
+                        <ul class="versions">
+                            {{versions}}
+                        </ul>
+                    </nav>
+                </aside>
+            </main>
+            <footer class="footer">
+                <span class="version"><a href="{{version}}/source">{{project}}</a> <em class="icon-tag">{{tag}}</em></span>
+                <a title="Go to top of the page" class="go-top icon-up screenreader" href="{{version}}/{{url}}#">Top</a>
+                <span class="poweredby">powered by <a target="_blank" href="https://github.com/bootlin/elixir">Elixir 1.0</a></span>
+            </footer>
+        </div>
+        <script src="/script.js?v=3"></script>
+    </body>
 </html>

--- a/utils/index-all-repositories
+++ b/utils/index-all-repositories
@@ -19,9 +19,9 @@ index() {
 
     if [ "$remote" != "" ]
     then
-	cd $LXR_REPO_DIR
-	git remote add other $remote
-	git fetch other
+        cd $LXR_REPO_DIR
+        git remote add other $remote
+        git fetch other
     fi
 
     cd $ELIXIR_INSTALL
@@ -37,16 +37,16 @@ index() {
 
 if [ "$ELIXIR_ROOT" = "" ]
 then
-	echo "Error: ELIXIR_ROOT environment variable not set"
-	echo "It's where Elixir data are stored"
-	exit 1
+    echo "Error: ELIXIR_ROOT environment variable not set"
+    echo "It's where Elixir data are stored"
+    exit 1
 fi
 
 if [ "$ELIXIR_INSTALL" = "" ]
 then
-	echo "Error: ELIXIR_INSTALL environment variable not set"
-	echo "It's where Elixir code is stored"
-	exit 1
+    echo "Error: ELIXIR_INSTALL environment variable not set"
+    echo "It's where Elixir code is stored"
+    exit 1
 fi
 
 index amazon-freertos https://github.com/aws/amazon-freertos.git &


### PR DESCRIPTION
This is a bit of cleanup I noticed a few minutes ago.  Hope it helps!  Let me know if you have any questions or concerns.

- Change the few files that use leading tabs into leading spaces.  This way they match the other files in the repo.
- Add an [EditorConfig](https://editorconfig.org) file so that supported editors will automatically use spaces instead of tabs.  (Note: I am an EditorConfig developer.)
- (Extra) Add some common editor backup-file extensions to .gitignore.