### PR TITLE
Add t/interact.pl for interactive testing

### DIFF
--- a/t/TestEnvironment.pm
+++ b/t/TestEnvironment.pm
@@ -195,6 +195,23 @@ sub update_env {
     return $self;
 } #update_env()
 
+=head2 report
+
+Returns a human-readable report of the current environment's state.
+
+=cut
+
+sub report {
+    my $self = shift;
+    return <<EOT;
+Repository: @{[$self->lxr_repo_dir]}
+Database:   @{[$self->lxr_data_dir]}
+script.sh:  @{[$self->script_sh]}
+update.py:  @{[$self->update_py]}
+query.py:   @{[$self->query_py]}
+EOT
+} #report()
+
 =head2 DESTROY
 
 Destructor.  Called automatically.

--- a/t/TestHelpers.pm
+++ b/t/TestHelpers.pm
@@ -17,6 +17,7 @@ TestHelpers - Common routines for use in tests
 =head1 SYNOPSIS
 
 C<use TestHelpers;>, and all the functions below will be exported.
+TestHelpers also turns on L<strict> and L<warnings>.
 
 =cut
 
@@ -210,9 +211,20 @@ sub run_produces_ok {
 
 } #run_produces_ok()
 
+=head2 import
+
+Set up.  Called automatically.
+
+=cut
+
+sub import {
+    __PACKAGE__->export_to_level(1, @_);
+    strict->import;
+    warnings->import;
+} #import()
+
 1;
 __END__
-
 
 =head1 AUTHOR
 

--- a/t/interact.pl
+++ b/t/interact.pl
@@ -1,0 +1,50 @@
+#!/usr/bin/env perl
+# t/interact.pl: Open a shell on a DB of the files in tree/ .
+#
+# Copyright (c) 2020 Christopher White, <cxwembedded@gmail.com>.
+#
+# Elixir is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Elixir is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+# # You should have received a copy of the GNU Affero General Public License
+# along with Elixir.  If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file uses core Perl modules only.
+
+use autodie;
+
+use FindBin '$Bin';
+use lib $Bin;
+
+use TestEnvironment;
+use TestHelpers;
+
+# ===========================================================================
+# Main
+
+# These two lines are all that's required to set up for a test.
+my $tenv = TestEnvironment->new;
+$tenv->build_repo(sibling_abs_path('tree'))->build_db->update_env;
+
+print($tenv->report);
+
+# Make some convenient symlinks
+chdir($tenv->lxr_repo_dir);
+system(qw(ln -s), $tenv->script_sh, 'script.sh') == 0
+    or warn "error creating ./script.sh: $? $!";
+system(qw(ln -s), $tenv->update_py, 'update.py') == 0
+    or warn "error creating ./update.py: $? $!";
+system(qw(ln -s), $tenv->query_py, 'query.py') == 0
+    or warn "error creating ./query.py: $? $!";
+
+print("Exit when done, and the repository and database will be removed.\n");
+system($ENV{SHELL} || 'sh');
+


### PR DESCRIPTION
Run `./t/interact.pl` and it will build a database from `t/tree` and
leave you in a shell so you can experiment.  When you exit the shell,
the temporary repo and database will be cleaned up.  This script is not run by `prove`, so does not interfere with the automated testing.

Also:
- TestEnvironment: add report() function to produce a human-readable
  summary of the environment
- TestHelpers: turn on `strict` and `warnings` so the caller doesn't
  have to manually `use strict` and `use warnings`.