### PR TITLE
Extract doc comments - back-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
+# Generated files
 __pycache__
+tags
+/.cache/
+
+# Web-specific
 http/images
 http/*.html
 http/favicon.ico

--- a/api/api.py
+++ b/api/api.py
@@ -23,11 +23,11 @@ class IdentGetter:
             version = req.params['version']
         else:
             raise falcon.HTTPMissingParam('version')
-        
+
         if version == 'latest':
             version = query('latest')
 
-        symbol_definitions, symbol_references = query('ident', version, ident)
+        symbol_definitions, symbol_references, symbol_doccomments_UNUSED = query('ident', version, ident)
         resp.body = json.dumps(
             {
                 'definitions': [sym.__dict__ for sym in symbol_definitions],

--- a/data.py
+++ b/data.py
@@ -49,6 +49,8 @@ defTypeD = {v: k for k, v in defTypeR.items()}
 maxId = 999999999
 
 class DefList:
+    '''Stores associations between a blob ID, a type (e.g., "function"),
+        and a line number.'''
     def __init__(self, data=b''):
         self.data = data
 
@@ -75,6 +77,8 @@ class DefList:
         return self.data
 
 class PathList:
+    '''Stores associations between a blob ID and a file path.
+        Inserted by update.py sorted by blob ID.'''
     def __init__(self, data=b''):
         self.data = data
 
@@ -96,6 +100,7 @@ class PathList:
         return self.data
 
 class RefList:
+    '''Stores a mapping from blob ID to list of lines.'''
     def __init__(self, data=b''):
         self.data = data
 
@@ -162,9 +167,15 @@ class DB:
         ro = readonly
 
         self.vars = BsdDB(dir + '/variables.db', ro, lambda x: int(x.decode()) )
+            # Key-value store of basic information
         self.blob = BsdDB(dir + '/blobs.db', ro, lambda x: int(x.decode()) )
+            # Map hash to sequential integer serial number
         self.hash = BsdDB(dir + '/hashes.db', ro, lambda x: x )
+            # Map serial number back to hash
         self.file = BsdDB(dir + '/filenames.db', ro, lambda x: x.decode() )
+            # Map serial number to filename
         self.vers = BsdDB(dir + '/versions.db', ro, PathList)
         self.defs = BsdDB(dir + '/definitions.db', ro, DefList)
         self.refs = BsdDB(dir + '/references.db', ro, RefList)
+        self.docs = BsdDB(dir + '/doccomments.db', ro, RefList)
+            # Use a RefList in case there are multiple doc comments for an identifier

--- a/find-file-doc-comments.pl
+++ b/find-file-doc-comments.pl
@@ -1,0 +1,100 @@
+#!/usr/bin/env perl
+# find-file-doc-comments.pl: Find the doc comments for a file.
+# Usage: find-file-doc-comments.pl <C source file name>
+# By Christopher White <cwhite@d3engineering.com>
+# Copyright (c) 2019 D3 Engineering, LLC.
+# Licensed AGPLv3
+
+use 5.010001;
+use strict;
+use warnings;
+use autodie;
+
+my $VERBOSE = $ENV{V};
+
+exit main(@ARGV);
+
+sub main {
+    die "Need a filename" unless @_;
+
+    # Do `script.sh parse-defs` on the file
+    my @ctags = qx{ ctags -x --c-kinds=+p-m --language-force=C "$_[0]" |
+            grep -av "^operator " |
+            awk '{print \$1" "\$2" "\$3}' };
+    die "Could not get ctags: $!" if $!;
+    print "No ctags results" if $VERBOSE && !@ctags;
+    return 0 unless @ctags;
+
+    # Make a list of [name, type, line] arrays
+    my @ctags_parsed = map { [split] } @ctags;
+
+    # Flip it around to index functions by line
+    my %function_lines;
+    for my $tag (@ctags_parsed) {
+        next unless $tag->[1] eq 'function';
+        $function_lines{$tag->[2]} = $tag->[0];
+    }
+
+    if($VERBOSE) {
+        for my $tag (@ctags_parsed) {
+            say $tag->[2], ': ', $tag->[0], ' is a(n) ', $tag->[1];
+        }
+    }
+
+    # Read the source file
+    open my $fh, '<', $_[0];
+    my @source_lines = (undef, <$fh>);
+        # undef => indices in @source_lines match ctags's 1-based linenos
+    close $fh;
+
+    # Work backwards through the file and look for doc comments
+    my %doc_comments;
+
+    my $doc_comment_opener = qr{^\s*\/\*\*(?:\s|$)};    # Start of doc comment
+
+    for(my $lineno = $#source_lines ; $lineno >= 1 ; --$lineno) {
+        next unless exists $function_lines{$lineno};
+        my $func_name = $function_lines{$lineno};
+        print "Checking for $func_name @ $lineno\n" if $VERBOSE;
+
+        my $this_doc_comment_header =
+            qr{^\s+\*\s+\Q$func_name\E(?:\s|\(|$)};
+        print "  Regex is -$this_doc_comment_header-\n" if $VERBOSE;
+        --$lineno;
+        print "  Line $lineno is: $source_lines[$lineno]\n" if $VERBOSE;
+
+        # Find the last line that could be a doc-comment header
+        # for this function.
+        while($source_lines[$lineno] =~
+            qr{
+                    ^\s*$               # Empty line
+                |   ^\s+\*\/            # End of comment
+                |   ^\s+\*(?:\s|$)      # Continuation of comment
+                |   $this_doc_comment_header
+            }x) {
+            print "$source_lines[$lineno] passed\n" if $VERBOSE;
+            --$lineno;
+        }
+        ++$lineno;  # Check the last line that matched,
+                    # because we may have just skipped past $this_doc_comment_header
+
+        # Is it actually a header for this function?
+        print "Checking $source_lines[$lineno] for header\n" if $VERBOSE;
+        next unless $source_lines[$lineno] =~ $this_doc_comment_header;
+
+        # We have found a header.  Confirm it's a doc comment.
+        --$lineno;
+        next unless $source_lines[$lineno] =~ $doc_comment_opener;
+        print "  * Match\n" if $VERBOSE;
+
+        # We have found a doc comment for this function!  Record it.
+        push @{$doc_comments{$func_name}}, $lineno;
+    }
+
+    # Report the doc comments for each function
+    while(my ($funcname, $comment_lines) = each %doc_comments) {
+        print "$funcname $_\n" foreach @$comment_lines;
+    }
+
+    return 0;
+}

--- a/http/web.py
+++ b/http/web.py
@@ -294,7 +294,7 @@ if mode == 'source':
 elif mode == 'ident':
     data['title'] = ident+' identifier - '+title_suffix
 
-    symbol_definitions, symbol_references = query('ident', tag, ident)
+    symbol_definitions, symbol_references, symbol_doccomments_UNUSED = query('ident', tag, ident)
 
     print('<div class="lxrident">')
     if len(symbol_definitions):

--- a/script.sh
+++ b/script.sh
@@ -2,8 +2,8 @@
 
 #  This file is part of Elixir, a source code cross-referencer.
 #
-#  Copyright (C) 2017  Mikaël Bouillot
-#  <mikael.bouillot@bootlin.com>
+#  Copyright (C) 2017--2020  Mikaël Bouillot
+#  <mikael.bouillot@bootlin.com> and contributors
 #
 #  Elixir is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU Affero General Public License as published by
@@ -22,6 +22,13 @@ if [ ! -d "$LXR_REPO_DIR" ]; then
     echo "$0: Can't find repository"
     exit 1
 fi
+
+# Get our path so we can find peer find-file-doc-comments.pl later
+cur_dir=`pwd`
+script_path=`realpath "$0"`
+cd `dirname "$script_path"`
+script_dir=`pwd`
+cd "$cur_dir"
 
 version_dir()
 {
@@ -140,6 +147,16 @@ parse_defs()
     rmdir $tmp
 }
 
+parse_docs()
+{
+    tmpfile=`mktemp`
+
+    git cat-file blob "$opt1" > "$tmpfile"
+    "$script_dir/find-file-doc-comments.pl" "$tmpfile"
+
+    rm -rf "$tmpfile"
+}
+
 project=$(basename `dirname $LXR_REPO_DIR`)
 
 plugin=projects/$project.sh
@@ -206,6 +223,10 @@ case $cmd in
 
     parse-defs)
         parse_defs
+        ;;
+
+    parse-docs)
+        parse_docs
         ;;
 
     help)

--- a/t/300-doc-comments.t
+++ b/t/300-doc-comments.t
@@ -1,0 +1,63 @@
+#!/usr/bin/env perl
+# 300-doc-comments.t: Test elixir doc-comment extraction against the files in tree/ .
+#
+# Copyright (c) 2020 Christopher White.
+# Copyright (c) 2020 D3 Engineering, LLC.
+# By Christopher White, <cwhite@d3engineering.com>.
+#
+# Elixir is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Elixir is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Elixir.  If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This file uses core Perl modules only.
+
+use autodie;    # note: still need to check system() calls manually
+
+use FindBin '$Bin';
+use lib $Bin;
+
+use Test::More;
+
+use TestEnvironment;
+use TestHelpers;
+
+# ===========================================================================
+# Main
+
+# Set up
+my $tenv = TestEnvironment->new;
+$tenv->build_repo(sibling_abs_path('tree'))->build_db->update_env;
+
+ok_or_die( -d $tenv->lxr_data_dir, 'database dir exists',
+    "Database dir @{[$tenv->lxr_data_dir]} not present");
+
+# Spot-check some identifiers
+
+run_produces_ok('doc-comment query (nonexistent)',
+    [$tenv->query_py, qw(v5.4 ident SOME_NONEXISTENT_IDENTIFIER_XYZZY_PLUGH)],
+    [
+        qr{^Documented in:},
+        { not => qr{/} }    # No file paths in the output
+    ],
+    MUST_SUCCEED);
+
+run_produces_ok('ident query (existent, function, documented in C file)',
+    [$tenv->query_py, qw(v5.4 ident i2c_acpi_get_i2c_resource)],
+    [
+        qr{^Documented in:},
+        qr{drivers/i2c/i2c-core-acpi\.c.+\b45\b},
+    ],
+    MUST_SUCCEED);
+
+done_testing;

--- a/t/300-doc-comments.t
+++ b/t/300-doc-comments.t
@@ -48,7 +48,15 @@ run_produces_ok('doc-comment query (nonexistent)',
     [$tenv->query_py, qw(v5.4 ident SOME_NONEXISTENT_IDENTIFIER_XYZZY_PLUGH)],
     [
         qr{^Documented in:},
-        { not => qr{/} }    # No file paths in the output
+        {doc => { not => qr{/} }},   # No file paths in the doc section
+    ],
+    MUST_SUCCEED);
+
+run_produces_ok('doc-comment query (existent but not documented)',
+    [$tenv->query_py, qw(v5.4 ident gsb_buffer)],   # in drivers/i2c/i2c-core-acpi.c
+    [
+        qr{^Documented in:},
+        {doc => { not => qr{/} }}
     ],
     MUST_SUCCEED);
 
@@ -56,7 +64,7 @@ run_produces_ok('ident query (existent, function, documented in C file)',
     [$tenv->query_py, qw(v5.4 ident i2c_acpi_get_i2c_resource)],
     [
         qr{^Documented in:},
-        qr{drivers/i2c/i2c-core-acpi\.c.+\b45\b},
+        {doc => qr{drivers/i2c/i2c-core-acpi\.c.+\b45\b}},
     ],
     MUST_SUCCEED);
 

--- a/t/TestEnvironment.pm
+++ b/t/TestEnvironment.pm
@@ -69,6 +69,10 @@ As L</script_sh>, but for C<query.py>.
 
 As L</script_sh>, but for C<update.py>.
 
+=head2 find_doc
+
+As L</script_sh>, but for C<find-file-doc-comments.pl>.
+
 =cut
 
 has lxr_data_dir => ();
@@ -81,6 +85,9 @@ has query_py => (
 );
 has update_py => (
     default => sub { find_program('update.py') }
+);
+has find_doc => (
+    default => sub { find_program('find-file-doc-comments.pl') }
 );
 
 # Internal attributes
@@ -204,11 +211,12 @@ Returns a human-readable report of the current environment's state.
 sub report {
     my $self = shift;
     return <<EOT;
-Repository: @{[$self->lxr_repo_dir]}
-Database:   @{[$self->lxr_data_dir]}
-script.sh:  @{[$self->script_sh]}
-update.py:  @{[$self->update_py]}
-query.py:   @{[$self->query_py]}
+Repository: @{[$self->lxr_repo_dir || '<unknown>']}
+Database:   @{[$self->lxr_data_dir || '<unknown>']}
+script.sh:  @{[$self->script_sh || '<unknown>']}
+update.py:  @{[$self->update_py || '<unknown>']}
+query.py:   @{[$self->query_py || '<unknown>']}
+find-file-doc-comments.pl: @{[$self->find_doc || '<unknown>']}
 EOT
 } #report()
 

--- a/t/TestHelpers.pm
+++ b/t/TestHelpers.pm
@@ -48,7 +48,7 @@ BEGIN {
     %EXPORT_TAGS = (
         all => [@EXPORT, @EXPORT_OK],
     );
-}
+} #BEGIN
 
 # Forwards for internal functions
 sub line_mark_string;
@@ -80,7 +80,7 @@ this file.  Usage:
 
 sub sibling_abs_path {
     return File::Spec->rel2abs(File::Spec->catfile($FindBin::Bin, @_));
-}
+} #sibling_abs_path()
 
 =head2 find_program
 
@@ -157,11 +157,46 @@ Usage:
     run_produces_ok($desc, \@program_and_args, \@expected_regexes,
                     <optional> $mustSucceed, <optional> $printOutput)
 
-The test passes if each regex in C<@expected_regexes> matches at least one
-line in the output of C<@program_and_args>, and if each C<< { not => regex } >>
-in C<@expected_regexes> is NOT found in that output.
+The test passes if each condition in C<@conditions> is true.
 If C<$mustSucceed> is true, also tests for exit status 0 and empty stderr.
 If C<$printOutput> is true, prints the output of C<@program_and_args>.
+
+=head3 Conditions that can be used any time
+
+=over
+
+=item *
+
+A regex: true if the regex matches at least one line in the output of
+C<@program_and_args>
+
+=item *
+
+C<< { not => regex } >>: true if the regex is NOT found in any line of
+the output of C<@program_and_args>.
+
+=back
+
+=head3 Conditions for the output of C<query.py>
+
+=over
+
+=item *
+
+C<< { def => regex } >>: true if the regex matches at least one line in
+the "Symbol Definitions" section of the output of C<@program_and_args>.
+
+=item *
+
+C<< { ref => regex } >>: true if the regex matches at least one line in
+the "Symbol References" section of the output of C<@program_and_args>.
+
+=item *
+
+C<< { doc => regex } >>: true if the regex matches at least one line in
+the "Documented in" section of the output of C<@program_and_args>.
+
+=back
 
 =cut
 
@@ -211,20 +246,29 @@ EOT
     }
 
     # Check regexes
+    my %query_py_output;    # filled in only if we see a def/ref/doc
     for my $entry (@$lrRegexes) {
+        my ($re, $negated, $source) = _parse_condition($entry);
 
-        if(ref $entry eq 'Regexp') {
-            eval line_mark_string 1,
-            q(ok( (grep { m{$entry} } @outlines), "$desc: output includes $entry" ));
+        # Parse query.py output if we need it and haven't done so
+        %query_py_output = _parseq(@outlines)
+            if $source ne 'output' && !%query_py_output;
 
-        } elsif(ref $entry eq 'HASH' && ref $entry->{not} eq 'Regexp') {
-            my $re = $entry->{not};
-            eval line_mark_string 1,
-            q(ok( !(grep { m{$re} } @outlines), "$desc: output excludes $re" ));
-
+        # Build a line of test code to run
+        my $test = 'ok( ';
+        $test .= '!' if $negated;
+        $test .= '(grep { m{$re} } ';
+        if($source eq 'output') {
+            $test .= '@outlines';
         } else {
-            die "Invalid entry $entry";
+            $test .= '@{$query_py_output{' . $source . '}}';
         }
+        $test .= '), "$desc: ' . $source;
+        $test .= ($negated ? ' excludes ' : ' includes ') . "\Q$re\E" . '");';
+
+        # Run it
+        #diag "Running $test";
+        eval line_mark_string 1, $test;
     } #foreach $entry
 
 } #run_produces_ok()
@@ -233,16 +277,75 @@ EOT
 
 These are ones you probably won't need to call.
 
+=head2 _parseq
+
+Parse the output of query.py.  Usage:
+
+    %parsed = _parseq(@lines_of_output);
+
+=cut
+
+sub _parseq {
+    my %retval = { def => [], ref => [], doc => [] };
+    my $list;
+    foreach(@_) {
+        chomp;
+        if($_ eq 'Symbol Definitions:') {
+            $list = 'def';
+            next;
+        } elsif($_ eq 'Symbol References:') {
+            $list = 'ref';
+            next;
+        } elsif($_ eq 'Documented in:') {
+            $list = 'doc';
+            next;
+        }
+
+        #diag "Adding `$_' to list $list";
+        push @{$retval{$list}}, $_;
+    }
+    return %retval;
+} #_parseq()
+
+=head2 _parse_condition
+
+Parse a condition for L</run_produces_ok>.  Usage:
+
+    ($regex, $negated, $source) = _parse_condition($entry[, $source]);
+
+=cut
+
+sub _parse_condition {
+    my ($entry, $source_in) = @_;
+    my ($regex, $negated, $source);     # Return values
+
+    # Basic cases
+    if(ref $entry eq 'Regexp') {
+        return ($entry, 0, $source_in || 'output');
+    } elsif(ref $entry eq 'HASH' && ref $entry->{not} eq 'Regexp') {
+        return ($entry->{not}, 1, $source_in || 'output');
+    }
+
+    # Sub-keys: chain
+    if(ref $entry eq 'HASH' && scalar keys %{$entry} == 1) {
+        return _parse_condition((values %{$entry})[0], (keys %{$entry})[0]);
+    }
+
+    # If we get here, we don't know how to handle it
+    die "Invalid entry $entry";
+} #_parse_condition()
+
+
 =head2 _croak
 
-Lazy L<Carp/croak>
+Lazy invoker for L<Carp/croak>.
 
 =cut
 
 sub _croak {
     require Carp;
     goto &Carp::croak;
-}
+} #_croak()
 
 =head2 line_mark_string
 

--- a/t/interact.pl
+++ b/t/interact.pl
@@ -19,8 +19,6 @@
 #
 # This file uses core Perl modules only.
 
-use autodie;
-
 use FindBin '$Bin';
 use lib $Bin;
 
@@ -32,7 +30,10 @@ use TestHelpers;
 
 # These two lines are all that's required to set up for a test.
 my $tenv = TestEnvironment->new;
-$tenv->build_repo(sibling_abs_path('tree'))->build_db->update_env;
+$tenv->build_repo(sibling_abs_path('tree'));	# dies on error
+eval { $tenv->build_db; };
+warn "Could not update database: $@" if $@;
+$tenv->update_env;
 
 print($tenv->report);
 
@@ -44,7 +45,9 @@ system(qw(ln -s), $tenv->update_py, 'update.py') == 0
     or warn "error creating ./update.py: $? $!";
 system(qw(ln -s), $tenv->query_py, 'query.py') == 0
     or warn "error creating ./query.py: $? $!";
+system(qw(ln -s), $tenv->find_doc, 'find-file-doc-comments.pl') == 0
+    or warn "error creating ./find-file-doc-comments.pl: $? $!";
 
 print("Exit when done, and the repository and database will be removed.\n");
-system($ENV{SHELL} || 'sh');
-
+my $retval = system($ENV{SHELL} || 'sh');
+exit $retval>>8;


### PR DESCRIPTION
(I will rebase this after some of the other open PRs are merged, but I wanted to post it now to provide an opportunity for feedback.)

This PR adds back-end support for doc-comment extraction (part of #78).  It does not update api.py or web.py.

### Notes on some specific points

While reading through the existing Python code, I found a number of the variable names confusing.  For example, in update.py, "blob" isn't a hash; it's a sequential ID that maps to a blob in a particular tag.  I changed some of the variable names to try to reduce confusion for myself and for future readers :) .  I can certainly change them back and add comments if you wish.

In query.py, subcommand `ident` has a loop over blobs to collect all the defs and refs.  I needed to add doc comments to that loop, and took advantage of the opportunity to express the logic in a way I believe is more clear.  Again, feel free to disagree --- comments welcome!

### Overview of changes

- find-file-doc-comments.pl: new script that finds doc comments in a source file
- data.py: Add database to store doc-comment locations
- script.sh: Add parse-docs subcommand
- update.py:
  - Add code to process doc comments
  - Update some variable names in hopes of reducing confusion
- query.py:
  - Add code to report doc comments
  - Update some variable names in hopes of reducing confusion

Also:
- t/TestEnvironment.pm: Add find_doc attribute
- t/interact.pl: Don't die if update.py fails
- t/TestHelpers.pm: Permit checking specific sections of query.py output
- t/300: update regexes per the preceding
- gitignore tags (`ctags -R` output)