### PR TITLE
doc-comments: support uncommented first function

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -152,7 +152,7 @@ parse_docs()
     tmpfile=`mktemp`
 
     git cat-file blob "$opt1" > "$tmpfile"
-    "$script_dir/find-file-doc-comments.pl" "$tmpfile"
+    "$script_dir/find-file-doc-comments.pl" "$tmpfile" || exit "$?"
 
     rm -rf "$tmpfile"
 }

--- a/t/300-doc-comments.t
+++ b/t/300-doc-comments.t
@@ -68,4 +68,12 @@ run_produces_ok('ident query (existent, function, documented in C file)',
     ],
     MUST_SUCCEED);
 
+run_produces_ok('ident query (existent, function, documented in C file, #102)',
+    [$tenv->query_py, qw(v5.4 ident documented_function_XYZZY)],
+    [
+        qr{^Documented in:},
+        {doc => qr{issue102\.c.+\b6\b}},
+    ],
+    MUST_SUCCEED);
+
 done_testing;

--- a/t/TestHelpers.pm
+++ b/t/TestHelpers.pm
@@ -286,7 +286,7 @@ Parse the output of query.py.  Usage:
 =cut
 
 sub _parseq {
-    my %retval = { def => [], ref => [], doc => [] };
+    my %retval = ( def => [], ref => [], doc => [] );
     my $list;
     foreach(@_) {
         chomp;

--- a/t/tree/issue102.c
+++ b/t/tree/issue102.c
@@ -1,0 +1,14 @@
+void foo(void)
+{
+}
+/* This file triggers the bug described in #102. */
+
+/**
+ * documented_function_XYZZY
+ */
+void documented_function_XYZZY(void)
+{
+}
+
+/* t/tree/issue102.c */
+/* SPDX-License-Identifier: CC0-1.0 */


### PR DESCRIPTION
If the first function in a file does not have a doc comment, do not
run off the beginning of the file.  Fixes #102.

Also:
- Add t/tree/issue102.c that exhibits this bug.
- in find-file-doc-comments.pl and script.sh, exit with a nonzero code
  if this should recur.