### PR TITLE
Use pytest-3(1) expressly

### DIFF
--- a/t/200-api.t
+++ b/t/200-api.t
@@ -31,6 +31,6 @@ my $tenv = TestEnvironment->new;
 $tenv->build_repo(sibling_abs_path('tree'))->build_db->update_env;
 
 # Test the api using pytest. Prints the test results
-run_produces_ok('api pytest suite', ["pytest", "-v"], [], MUST_SUCCEED, 1);
+run_produces_ok('api pytest suite', ["pytest-3", "-v"], [], MUST_SUCCEED, 1);
 
 done_testing;


### PR DESCRIPTION
On systems having pytest(1) as Python 2, this will use the correct (Python 3) version of pytest.

Relates to https://github.com/bootlin/elixir/pull/95#issuecomment-609065373