### PR TITLE
Encode slashes in URL

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -216,6 +216,8 @@ AddHandler cgi-script .py
     # To enable REST api after installing mod_wsgi: Fill path and uncomment:
     #WSGIScriptAlias /api /usr/local/elixir/api/api.py
 
+    AllowEncodedSlashes On
+
     RewriteEngine on
     RewriteRule "^/$" "/linux/latest/source" [R]
     RewriteRule "^/(?!api).*/(source|ident|search)" "/web.py" [PT]

--- a/http/web.py
+++ b/http/web.py
@@ -53,7 +53,7 @@ m = search('^/([^/]*)/([^/]*)/([^/]*)(.*)$', url)
 if m:
     project = m.group(1)
     version = m.group(2)
-    versionDecoded = parse.unquote(version)
+    version_decoded = parse.unquote(version)
     cmd = m.group(3)
     arg = m.group(4)
 
@@ -126,10 +126,10 @@ import sys
 sys.path = [ sys.path[0] + '/..' ] + sys.path
 from query import query
 
-if versionDecoded == 'latest':
+if version_decoded == 'latest':
     tag = query('latest')
 else:
-    tag = versionDecoded
+    tag = version_decoded
 
 data = {
     'baseurl': '/' + project + '/',
@@ -162,9 +162,9 @@ for topmenu in versions:
             v += '\t\t\t<span>'+submenu+'</span>\n'
             v += '\t\t\t<ul>\n'
             for _tag in tags:
-                _tagEncoded = parse.quote(_tag, safe='')
-                if _tag == tag: v += '\t\t\t\t<li class="li-link active"><a href="'+_tagEncoded+'/'+url+'">'+_tag+'</a></li>\n'
-                else: v += '\t\t\t\t<li class="li-link"><a href="'+_tagEncoded+'/'+url+'">'+_tag+'</a></li>\n'
+                _tag_encoded = parse.quote(_tag, safe='')
+                if _tag == tag: v += '\t\t\t\t<li class="li-link active"><a href="'+_tag_encoded+'/'+url+'">'+_tag+'</a></li>\n'
+                else: v += '\t\t\t\t<li class="li-link"><a href="'+_tag_encoded+'/'+url+'">'+_tag+'</a></li>\n'
             v += '\t\t\t</ul></li>\n'
     v += '\t</ul></li>\n'
 

--- a/http/web.py
+++ b/http/web.py
@@ -53,6 +53,7 @@ m = search('^/([^/]*)/([^/]*)/([^/]*)(.*)$', url)
 if m:
     project = m.group(1)
     version = m.group(2)
+    versionDecoded = parse.unquote(version)
     cmd = m.group(3)
     arg = m.group(4)
 
@@ -125,10 +126,10 @@ import sys
 sys.path = [ sys.path[0] + '/..' ] + sys.path
 from query import query
 
-if version == 'latest':
+if versionDecoded == 'latest':
     tag = query('latest')
 else:
-    tag = version
+    tag = versionDecoded
 
 data = {
     'baseurl': '/' + project + '/',
@@ -161,8 +162,9 @@ for topmenu in versions:
             v += '\t\t\t<span>'+submenu+'</span>\n'
             v += '\t\t\t<ul>\n'
             for _tag in tags:
-                if _tag == tag: v += '\t\t\t\t<li class="li-link active"><a href="'+_tag+'/'+url+'">'+_tag+'</a></li>\n'
-                else: v += '\t\t\t\t<li class="li-link"><a href="'+_tag+'/'+url+'">'+_tag+'</a></li>\n'
+                _tagEncoded = parse.quote(_tag, safe='')
+                if _tag == tag: v += '\t\t\t\t<li class="li-link active"><a href="'+_tagEncoded+'/'+url+'">'+_tag+'</a></li>\n'
+                else: v += '\t\t\t\t<li class="li-link"><a href="'+_tagEncoded+'/'+url+'">'+_tag+'</a></li>\n'
             v += '\t\t\t</ul></li>\n'
     v += '\t</ul></li>\n'
 


### PR DESCRIPTION
This allow the use of tags with slashes by encoding them in the links and decoding them when needed.
And thus it fix issue https://github.com/bootlin/elixir/issues/106

Apache need a special configuration when we encode slashes in URL so I updated the documentation according to that.