### PR TITLE
API: Always set LXR_DATA_DIR and LXR_REPO_DIR based on LXR_PROJ_DIR.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ before_install:
   - sudo dpkg -i universal-ctags_0+git20221222-0ubuntu1_amd64.deb
 
 script:
-  - prove
+  - prove -v

--- a/api/api.py
+++ b/api/api.py
@@ -5,13 +5,17 @@ import os
 
 import falcon
 
-ELIXIR_DIR = os.path.dirname(__file__) + '/..'
+ELIXIR_DIR = os.path.dirname(os.path.realpath(__file__)) + '/..'
 
 def build_query(env, project):
-    if 'LXR_DATA_DIR' not in os.environ or 'LXR_REPO_DIR' not in os.environ:
+    try:
         basedir = env['LXR_PROJ_DIR']
-        os.environ['LXR_DATA_DIR']= basedir + '/' + project + '/data'
-        os.environ['LXR_REPO_DIR'] = basedir + '/' + project + '/repo'
+    except KeyError:
+        basedir = os.environ['LXR_PROJ_DIR']
+        # fail if it's not defined either place
+
+    os.environ['LXR_DATA_DIR']= basedir + '/' + project + '/data'
+    os.environ['LXR_REPO_DIR'] = basedir + '/' + project + '/repo'
 
     import sys
     sys.path = [ ELIXIR_DIR ] + sys.path

--- a/t/.gitignore
+++ b/t/.gitignore
@@ -1,2 +1,0 @@
-# Where we put the test database used by 100-basic.t
-/db/

--- a/t/100-basic.t
+++ b/t/100-basic.t
@@ -40,7 +40,6 @@ use TestHelpers;
 
 # Set up
 my $tree_src_dir = sibling_abs_path('tree');
-my $db_dir = sibling_abs_path('db');        # the db dir is .gitignored
 
 my $tenv = TestEnvironment->new;
 
@@ -59,6 +58,8 @@ ok_or_die( (-f $query_py && -r _ && -x _), 'query.py executable',
 $tenv->build_repo($tree_src_dir);
 $tenv->update_env;  # Set LXR_REPO_DIR
 
+diag $tenv->report;
+
 # Check for tags in `script.sh list-tags`, as a sanity check before
 # building the test DB
 my @tags = `$script_sh list-tags`;
@@ -66,8 +67,9 @@ die("Could not list tags: $! ($?)") if $?;
 ok_or_die( @tags == 1, 'One tag present', "Not one tag (@{[scalar @tags]})");
 ok_or_die( $tags[0] =~ /^v5.4$/, 'Found the correct tag', 'Not the tag we expected');
 
-$tenv->build_db($db_dir);
+$tenv->build_db;
 $tenv->update_env;  # Set LXR_DATA_DIR
+my $db_dir = $tenv->lxr_data_dir;
 
 ok_or_die( -d $db_dir, 'database dir exists',
     "Database dir $db_dir not present");
@@ -112,7 +114,5 @@ run_produces_ok('file query (existent), .h',
     [$query_py, qw(v5.4 file /drivers/i2c/i2c-core.h)],
     [qr{i2c-core\.h}, qr{\bWe\b}],
     MUST_SUCCEED);
-
-#system('bash'); # Uncomment this if you want to interact with the test repo
 
 done_testing;

--- a/t/TestEnvironment.pm
+++ b/t/TestEnvironment.pm
@@ -24,6 +24,9 @@ TestEnvironment - Class representing an Elixir test environment
     $tenv->export_env;                  # Set $LXR_* environment vars
     # Now run tests against the database in $db_path
 
+This module creates a temporary project dir and populates it with repo and
+data subdirs in a single project, named "testproj".
+
 =cut
 
 package TestEnvironment;
@@ -44,7 +47,14 @@ use Test::More;
 
 use TestHelpers;
 
+use constant PROJECT => 'testproj';
+
 =head1 ATTRIBUTES
+
+=head2 lxr_proj_dir
+
+C<$lxr_proj_dir> is the value to use in the C<LXR_DATA_DIR> environment
+variable.
 
 =head2 lxr_data_dir
 
@@ -69,12 +79,17 @@ As L</script_sh>, but for C<query.py>.
 
 As L</script_sh>, but for C<update.py>.
 
+=head2 web_py
+
+As L</script_sh>, but for C<web.py>.
+
 =head2 find_doc
 
 As L</script_sh>, but for C<find-file-doc-comments.pl>.
 
 =cut
 
+has lxr_proj_dir => ();
 has lxr_data_dir => ();
 has lxr_repo_dir => ();
 has script_sh => (
@@ -86,19 +101,18 @@ has query_py => (
 has update_py => (
     default => sub { find_program('update.py') }
 );
+has web_py => (
+    default => sub { find_program(qw(http web.py)) }
+);
 has find_doc => (
     default => sub { find_program('find-file-doc-comments.pl') }
 );
 
 # Internal attributes
 
-# a variable representing the temporary repository directory.
+# a variable representing the temporary project directory.
 # When this goes out of scope, the directory will be removed.
-has _repo_dir_token => ();
-
-# a variable representing the temporary DB directory, if any.
-# When this goes out of scope, the directory will be removed.
-has _data_dir_token => ();
+has _proj_dir_token => ();
 
 =head1 MEMBER FUNCTIONS
 
@@ -118,25 +132,21 @@ Dies on error.  On success, returns the instance, for chaining.
 sub build_repo {
     my ($self, $tree_src_dir) = @_;
     die "Need a source dir" unless $tree_src_dir;
+    die "No repo dir" unless $self->lxr_repo_dir;
 
-    my $tempdir = tempdir(CLEANUP => 1);
-    my $tempdir_path = abs_path($tempdir);
+    my $tempdir_path = $self->lxr_repo_dir;
     my @gitdir = ('-C', $tempdir_path);
 
     diag "Using temporary directory $tempdir_path";
     run_program('git', 'init', $tempdir_path) or die("git init failed");
 
-    run_program('bash', '-c', "tar cf - -C \"$tree_src_dir\" . | tar xf - -C \"$tempdir_path\"")
+    run_program('sh', '-c', "tar cf - -C \"$tree_src_dir\" . | tar xf - -C \"$tempdir_path\"")
         or die("Could not copy files into $tempdir_path");
 
     run_program('git', @gitdir, 'add', '.') or die("git add failed");
     run_program('git', @gitdir, 'commit', '-am', 'Initial commit')
         or die("git commit failed");
     run_program('git', @gitdir, 'tag', 'v5.4') or die("git tag failed");
-
-    # Save the results in the instance
-    $self->_repo_dir_token($tempdir);
-    $self->lxr_repo_dir($tempdir_path);
 
     return $self;
 } #build_repo()
@@ -146,32 +156,24 @@ sub build_repo {
 Build a test database for the repository.  L</lxr_repo_dir> must be set
 before calling this.  Usage:
 
-    $tenv->build_db([$db_dir])
-
-C<$db_dir> is the directory where you want to put the database.  If you do
-not provide one, a temporary directory will be created.
+    $tenv->build_db()
 
 Dies on error.  On success, returns the instance, for chaining.
 
-B<CAUTION>: This function will remove the contents of C<$db_dir>
+B<CAUTION>: This function will remove the contents of C<< $tenv->lxr_data_dir >>
 unconditionally.
 
 =cut
 
 sub build_db {
-    my ($self, $db_dir) = @_;
+    my $self = shift;
     die "No repo dir" unless $self->lxr_repo_dir;
+    die "No data dir" unless $self->lxr_data_dir;
+    my $db_dir = $self->lxr_data_dir;
 
-    if($db_dir) {   # Remove any existing DB dir
+    if(-e $db_dir) {   # Remove any existing DB dir
         remove_tree($db_dir);
         mkdir($db_dir) or die "Could not create fresh $db_dir";
-    }
-
-    # Create a temp DB dir if necessary
-    my $temp_db_dir;
-    unless($db_dir) {
-        $temp_db_dir = tempdir(CLEANUP => 1);
-        $db_dir = abs_path($temp_db_dir);
     }
 
     local $ENV{LXR_REPO_DIR} = $self->lxr_repo_dir;
@@ -180,16 +182,14 @@ sub build_db {
     run_program($self->update_py)
         or die "Could not create database from $ENV{LXR_REPO_DIR} in $ENV{LXR_DATA_DIR}";
 
-    $self->_data_dir_token($temp_db_dir);
-    $self->lxr_data_dir($db_dir);
-
     return $self;
 } #build_db()
 
 =head2 update_env
 
-Set the C<LXR_REPO_DIR> and C<LXR_DATA_DIR> environment variables.
-Will not set a variable if the corresponding member does not have a value.
+Set the C<LXR_PROJ_DIR>, C<LXR_REPO_DIR>, and C<LXR_DATA_DIR> environment
+variables.  Will not set a variable if the corresponding member does not have
+a value.
 
 Returns the instance, for chaining.
 
@@ -197,6 +197,7 @@ Returns the instance, for chaining.
 
 sub update_env {
     my $self = shift;
+    $ENV{LXR_PROJ_DIR} = $self->lxr_proj_dir if $self->lxr_proj_dir;
     $ENV{LXR_REPO_DIR} = $self->lxr_repo_dir if $self->lxr_repo_dir;
     $ENV{LXR_DATA_DIR} = $self->lxr_data_dir if $self->lxr_data_dir;
     return $self;
@@ -211,14 +212,72 @@ Returns a human-readable report of the current environment's state.
 sub report {
     my $self = shift;
     return <<EOT;
+Project:    @{[$self->lxr_proj_dir || '<unknown>']}
 Repository: @{[$self->lxr_repo_dir || '<unknown>']}
 Database:   @{[$self->lxr_data_dir || '<unknown>']}
 script.sh:  @{[$self->script_sh || '<unknown>']}
 update.py:  @{[$self->update_py || '<unknown>']}
 query.py:   @{[$self->query_py || '<unknown>']}
+web.py:     @{[$self->web_py || '<unknown>']}
 find-file-doc-comments.pl: @{[$self->find_doc || '<unknown>']}
 EOT
 } #report()
+
+=head2 make_web_request
+
+Request a URL from L</web_py>.  Usage:
+
+    my $html = $tenv->make_web_request($url);
+        # Returns the HTML from stdout, or dies
+
+    my ($exit_status, $lrStdout, $lrStderr) = $tenv->make_web_request($url);
+        # Returns the shell exit status, stdout text, and stderr text.
+
+See L<TestEnvironment/run_program> for the details of the return values
+in the second case.
+
+=cut
+
+sub make_web_request {
+    my ($self, $url) = @_;
+
+    $self->update_env;  # just in case
+
+    local $ENV{REQUEST_URI} = $url;
+    my ($exit_status, $lrStdout, $lrStderr) = run_program($self->web_py);
+
+    if(!wantarray) {
+        return $lrStdout;
+    } else {
+        return ($exit_status, $lrStdout, $lrStderr);
+    }
+} #make_web_request()
+
+=head2 BUILD
+
+Constructor.  Creates the temporary project dir.
+
+=cut
+
+sub BUILD {
+    my $self = shift;
+
+    my $temp_proj_dir = tempdir(CLEANUP => 1);
+    my $proj_dir = abs_path($temp_proj_dir);
+
+    # Make the directory structure
+    mkdir File::Spec->catdir($proj_dir, PROJECT);
+    my $data_dir = File::Spec->catdir($proj_dir, PROJECT, 'data');
+    my $repo_dir = File::Spec->catdir($proj_dir, PROJECT, 'repo');
+    mkdir $data_dir;
+    mkdir $repo_dir;
+
+    # Save the paths
+    $self->_proj_dir_token($temp_proj_dir);
+    $self->lxr_proj_dir($proj_dir);
+    $self->lxr_data_dir($data_dir);
+    $self->lxr_repo_dir($repo_dir);
+} #BUILD()
 
 =head2 DESTROY
 
@@ -231,9 +290,8 @@ sub DESTROY {
     my $self = shift;
 
     # Release the temporary directories
-    $self->_data_dir_token(undef);
-    $self->_repo_dir_token(undef);
-}
+    $self->_proj_dir_token(undef);
+} #DESTROY()
 
 1;
 __END__

--- a/t/TestEnvironment.pm
+++ b/t/TestEnvironment.pm
@@ -20,7 +20,7 @@ TestEnvironment - Class representing an Elixir test environment
     use TestEnvironment;
     my $tenv = TestEnvironment->new;
     $tenv->build_repo($source_path);    # Make a git repo
-    $tenv->build_db($db_path);          # Run update.py
+    $tenv->build_db();                  # Run update.py
     $tenv->export_env;                  # Set $LXR_* environment vars
     # Now run tests against the database in $db_path
 
@@ -131,6 +131,7 @@ Dies on error.  On success, returns the instance, for chaining.
 
 sub build_repo {
     my ($self, $tree_src_dir) = @_;
+    die "Incorrect parameters" unless @_==2 && ref $self && $tree_src_dir;
     die "Need a source dir" unless $tree_src_dir;
     die "No repo dir" unless $self->lxr_repo_dir;
 
@@ -167,6 +168,7 @@ unconditionally.
 
 sub build_db {
     my $self = shift;
+    die "No parameters allowed" if @_;
     die "No repo dir" unless $self->lxr_repo_dir;
     die "No data dir" unless $self->lxr_data_dir;
     my $db_dir = $self->lxr_data_dir;

--- a/t/api_test.py
+++ b/t/api_test.py
@@ -5,7 +5,7 @@ import sys
 import falcon
 from falcon import testing
 
-api_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..','api'))
+api_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..','api'))
 sys.path.insert(0, api_dir)
 
 from api import create_ident_getter
@@ -17,14 +17,14 @@ class APITest(testing.TestCase):
         self.app = create_ident_getter()
 
     def test_identifier_not_found(self):
-        result = self.simulate_get('/ident/tree/SOME_NONEXISTENT_IDENTIFIER', query_string="version=latest&family=C")
+        result = self.simulate_get('/ident/testproj/SOME_NONEXISTENT_IDENTIFIER', query_string="version=latest&family=C")
 
         self.assertEqual(result.status_code, 200)
         self.assertEqual(result.json, {'definitions': [], 'references':[]})
 
     def test_missing_version(self):
         # A get request without a version query string
-        result = self.simulate_get('/ident/tree/of_i2c_get_board_info')
+        result = self.simulate_get('/ident/testproj/of_i2c_get_board_info', query_string="")
 
         self.assertEqual(result.status_code, 400)
 
@@ -33,25 +33,25 @@ class APITest(testing.TestCase):
         self.assertEqual(result.json["description"], required_response.description)
 
     def test_existing_identifier(self):
-        result_for_specific_version = self.simulate_get('/ident/tree/of_i2c_get_board_info', query_string="version=v5.4&family=C")
-        result_for_latest_version = self.simulate_get('/ident/tree/of_i2c_get_board_info', query_string="version=latest&family=C")
+        result_for_specific_version = self.simulate_get('/ident/testproj/of_i2c_get_board_info', query_string="version=v5.4&family=C")
+        result_for_latest_version = self.simulate_get('/ident/testproj/of_i2c_get_board_info', query_string="version=latest&family=C")
 
         expected_json = {
-            'definitions': 
+            'definitions':
             [
                 {'path': 'drivers/i2c/i2c-core-of.c', 'line': 22, 'type': 'function'},
                 {'path': 'include/linux/i2c.h', 'line': 968, 'type': 'function'},
                 {'path': 'include/linux/i2c.h', 'line': 941, 'type': 'prototype'}
-            ], 
-            'references': 
+            ],
+            'references':
                 [
                     {'path': 'drivers/i2c/i2c-core-of.c', 'line': '22,62,73', 'type': None},
                     {'path': 'include/linux/i2c.h', 'line': '941,968', 'type': None}
                 ]
             }
-        
+
         self.assertEqual(result_for_specific_version.status_code, 200)
         self.assertEqual(result_for_latest_version.status_code, 200)
-        
+
         self.assertEqual(result_for_specific_version.json, expected_json)
         self.assertEqual(result_for_latest_version.json, expected_json)

--- a/t/interact.pl
+++ b/t/interact.pl
@@ -22,13 +22,16 @@
 use FindBin '$Bin';
 use lib $Bin;
 
+use Cwd;
 use TestEnvironment;
 use TestHelpers;
 
 # ===========================================================================
 # Main
 
-# These two lines are all that's required to set up for a test.
+my $pwd = getcwd;
+
+# This block is all that's required to set up for a test.
 my $tenv = TestEnvironment->new;
 $tenv->build_repo(sibling_abs_path('tree'));	# dies on error
 eval { $tenv->build_db; };
@@ -45,9 +48,15 @@ system(qw(ln -s), $tenv->update_py, 'update.py') == 0
     or warn "error creating ./update.py: $? $!";
 system(qw(ln -s), $tenv->query_py, 'query.py') == 0
     or warn "error creating ./query.py: $? $!";
+system(qw(ln -s), $tenv->web_py, 'web.py') == 0
+    or warn "error creating ./web.py: $? $!";
 system(qw(ln -s), $tenv->find_doc, 'find-file-doc-comments.pl') == 0
     or warn "error creating ./find-file-doc-comments.pl: $? $!";
 
 print("Exit when done, and the repository and database will be removed.\n");
 my $retval = system($ENV{SHELL} || 'sh');
+
+# Don't stay in the temp dir --- the dir can't be removed if we are there.
+chdir $pwd;
+
 exit $retval>>8;


### PR DESCRIPTION
This implements https://github.com/bootlin/elixir/issues/129#issuecomment-632659022 , among other things.  I have added some explanatory comments on specific lines.

- Update the test infrastructure to create an LXR_PROJ_DIR structure.  This way we can test the http and api interfaces as well as the command-line interface.
- Update api.py to:
  - always set LXR_REPO_DIR and LXR_DATA_DIR based on LXR_PROJ_DIR.
  - use os.environ as a fallback for req.env

Also:

- add a helper function to the test infrastructure to test web.py.  A later PR will add tests using that function.
- fix a bug in t/interact.pl that could prevent deleting the temporary directory on exit.
- Travis: verbose output from `prove`, for easier failure diagnosis
- Fix a latent bug in t/100 --- when I refactored TestEnvironment, I forgot to update t/100 to reflect that build_db() no longer takes a parameter.  That is now corrected.

Sorry for the mixed contents!  I cherry-picked from my doc-comments dev branch in order to get #129 fixed, and some other changes came along for the ride.

Thanks for considering this PR!