### PR TITLE
filters/*idents.py: Add possible html tag added by pygments

### DIFF
--- a/http/filters/ident.py
+++ b/http/filters/ident.py
@@ -7,14 +7,14 @@ def keep_idents(m):
     return '__KEEPIDENTS__' + encode_number(len(idents))
 
 def replace_idents(m):
-    i = idents[decode_number(m.group(1)) - 1]
-    return '<a href="'+version+'/'+family+'/ident/'+i+'">'+i+'</a>'
+    i = idents[decode_number(m.group(2)) - 1]
+    return str(m.group(1) or '') + '<a href="'+version+'/'+family+'/ident/'+i+'">'+i+'</a>'
 
 ident_filters = {
                 'case': 'any',
                 'prerex': '\033\[31m(?!CONFIG_)(.*?)\033\[0m',
                 'prefunc': keep_idents,
-                'postrex': '__KEEPIDENTS__([A-J]+)',
+                'postrex': '__(<.+?>)?KEEPIDENTS__([A-J]+)',
                 'postfunc': replace_idents
                 }
 

--- a/http/filters/kconfigidents.py
+++ b/http/filters/kconfigidents.py
@@ -7,20 +7,20 @@ def keep_kconfigidents(m):
     return '__KEEPKCONFIGIDENTS__' + encode_number(len(kconfigidents))
 
 def replace_kconfigidents(m):
-    i = kconfigidents[decode_number(m.group(1)) - 1]
+    i = kconfigidents[decode_number(m.group(2)) - 1]
 
     n = i
     #Remove the CONFIG_ when we are in a Kconfig file
     if family == 'K':
         n = n[7:]
 
-    return '<a href="'+version+'/K/ident/'+i+'">'+n+'</a>'
+    return str(m.group(1) or '') + '<a href="'+version+'/K/ident/'+i+'">'+n+'</a>'
 
 kconfigident_filters = {
                 'case': 'any',
                 'prerex': '\033\[31m(?=CONFIG_)(.*?)\033\[0m',
                 'prefunc': keep_kconfigidents,
-                'postrex': '__KEEPKCONFIGIDENTS__([A-J]+)',
+                'postrex': '__(<.+?>)?KEEPKCONFIGIDENTS__([A-J]+)',
                 'postfunc': replace_kconfigidents
                 }
 


### PR DESCRIPTION
Fix problems when pigments add an html tag in the __KEEPIDENTS__XX like : 
`</span>__<span class="n">KEEPKCONFIGIDENTS__C</span>`