### PR TITLE
script.sh: Adapt to universal-ctags Kconfig parser

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -115,11 +115,11 @@ The changes have been sent upstream and should appear in future distributions.
 
 In the meantime, you can either rebuild this package from its source on
  https://github.com/MaximeChretien/ctags/tree/kconfig-parser[GitHub], or download this
-https://bootlin.com/pub/elixir/universal-ctags_0+git20221222-0ubuntu1_amd64.deb[binary package]
+https://bootlin.com/pub/elixir/universal-ctags_0+git20200526-0ubuntu1_amd64.deb[binary package]
 and install it as follows:
 
 ----
-sudo dpkg -i universal-ctags_0+git20221222-0ubuntu1_amd64.deb
+sudo dpkg -i universal-ctags_0+git20200526-0ubuntu1_amd64.deb
 ----
 
 Then tell `apt` to hold this package and block future updates of the normal package:

--- a/script.sh
+++ b/script.sh
@@ -173,7 +173,7 @@ parse_defs_K()
     tmp=`mktemp -d`
     full_path=$tmp/$opt2
     git cat-file blob "$opt1" > "$full_path"
-    ctags -x --language-force=kconfig "$full_path" |
+    ctags -x --language-force=kconfig --kinds-kconfig=c --extras-kconfig=-{configPrefixed} "$full_path" |
     awk '{print "CONFIG_"$1" "$2" "$3}'
     rm "$full_path"
     rmdir $tmp


### PR DESCRIPTION
The parser has been modified before being merged so we adapt to the
changes.

See : https://github.com/universal-ctags/ctags/pull/2553

/!\ NOTE : Merge only when we switch to universal-ctags upstream version /!\