### PR TITLE
Enable struct, enum and union members indexing

### DIFF
--- a/lib.py
+++ b/lib.py
@@ -155,6 +155,9 @@ blacklist = (
     b'driver',
     b'ptr',
     b'return',
+    b'int',
+    b'long',
+    b'char'
     )
 
 def isIdent(bstr):

--- a/script.sh
+++ b/script.sh
@@ -162,7 +162,7 @@ parse_defs_C()
     tmp=`mktemp -d`
     full_path=$tmp/$opt2
     git cat-file blob "$opt1" > "$full_path"
-    ctags -x --kinds-c=+p+x-m "$full_path" |
+    ctags -x --kinds-c=+p+x "$full_path" |
     grep -avE "^operator |CONFIG_" |
     awk '{print $1" "$2" "$3}'
     rm "$full_path"


### PR DESCRIPTION
Enable indexing of struct, enum and union members in Elixir

And adapt blacklist to avoid unneeded stuff

This fix : https://github.com/bootlin/elixir/issues/48