### PR TITLE
Devicetree compatible properties support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,6 +25,7 @@ toc::[]
 = Requirements
 
 * Python >= 3.6
+* Git >= 1.9
 * The Jinja2 and Pygments (>= 2.2) Python libraries
 * Berkeley DB (and its Python binding)
 * Universal Ctags
@@ -336,7 +337,7 @@ we're proposing to use a script like `utils/update-elixir-data` which is called
 through a daily cron job.
 
 You can set `$ELIXIR_THREADS` if you want to change the number of threads used by
-update.py for indexing.
+update.py for indexing (default is 10 and minimum is 5).
 
 == Keeping git repository disk usage under control
 
@@ -438,7 +439,7 @@ Depending on how you want to show the available versions on the Elixir pages,
 you may have to apply substitutions to each tag string, for example to add
 a `v` prefix if missing, for consistency with how other project versions are
 shown. You may also decide to ignore specific tags. All this can be done
-by redefining the default `list_tags()` function in a new `project/<projectname>.sh`
+by redefining the default `list_tags()` function in a new `projects/<projectname>.sh`
 file. Here's an example (`projects/zephyr.sh` file):
 
  list_tags()
@@ -480,6 +481,9 @@ the most recent versions:
  ./script.sh get-latest
 
 If needed, customize the `get_latest()` function.
+
+If you want to enable support for `compatible` properties in Devicetree files,
+add `dts_comp_support=1` at the beginning of `projects/<projectname>.sh`.
 
 You are now ready to generate Elixir's database for your
 new project:

--- a/README.adoc
+++ b/README.adoc
@@ -195,7 +195,7 @@ cd /usr/local/elixir/
 == Create Database
 
 ----
-./update.py <number of threads (default 8 | min 3)>
+./update.py <number of threads (default 10 | min 5)>
 ----
 
 ____
@@ -484,7 +484,7 @@ If needed, customize the `get_latest()` function.
 You are now ready to generate Elixir's database for your
 new project:
 
- ./update.py <number of threads (default 8 | min 3)>
+ ./update.py <number of threads (default 10 | min 5)>
 
 You can then check that Elixir works through your http server.
 

--- a/api/api.py
+++ b/api/api.py
@@ -21,6 +21,7 @@ import json
 import os
 
 import falcon
+from urllib import parse
 
 ELIXIR_DIR = os.path.dirname(os.path.realpath(__file__)) + '/..'
 
@@ -54,6 +55,9 @@ class IdentGetter:
             family = req.params['family']
         else:
             family = 'C'
+
+        if family == 'B': #DT compatible strings are quoted in the database
+            ident = parse.quote(ident)
 
         symbol_definitions, symbol_references, symbol_doccomments_UNUSED = query('ident', version, ident, family)
         resp.body = json.dumps(

--- a/data.py
+++ b/data.py
@@ -194,4 +194,5 @@ class DB:
         self.defs = BsdDB(dir + '/definitions.db', ro, DefList)
         self.refs = BsdDB(dir + '/references.db', ro, RefList)
         self.docs = BsdDB(dir + '/doccomments.db', ro, RefList)
+        self.comps = BsdDB(dir + '/compatibledts.db', ro, RefList)
             # Use a RefList in case there are multiple doc comments for an identifier

--- a/data.py
+++ b/data.py
@@ -174,7 +174,7 @@ class BsdDB:
             self.db.sync()
 
 class DB:
-    def __init__(self, dir, readonly=True):
+    def __init__(self, dir, readonly=True, dtscomp=False):
         if os.path.isdir(dir):
             self.dir = dir
         else:
@@ -194,5 +194,6 @@ class DB:
         self.defs = BsdDB(dir + '/definitions.db', ro, DefList)
         self.refs = BsdDB(dir + '/references.db', ro, RefList)
         self.docs = BsdDB(dir + '/doccomments.db', ro, RefList)
-        self.comps = BsdDB(dir + '/compatibledts.db', ro, RefList)
+        if dtscomp:
+            self.comps = BsdDB(dir + '/compatibledts.db', ro, RefList)
             # Use a RefList in case there are multiple doc comments for an identifier

--- a/data.py
+++ b/data.py
@@ -196,4 +196,5 @@ class DB:
         self.docs = BsdDB(dir + '/doccomments.db', ro, RefList)
         if dtscomp:
             self.comps = BsdDB(dir + '/compatibledts.db', ro, RefList)
+            self.comps_docs = BsdDB(dir + '/compatibledts_docs.db', ro, RefList)
             # Use a RefList in case there are multiple doc comments for an identifier

--- a/find_compatible_dts.py
+++ b/find_compatible_dts.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+#  This file is part of Elixir, a source code cross-referencer.
+#
+#  Copyright (C) 2017--2020  Maxime Chretien
+#  <maxime.chretien@bootlin.com> and contributors
+#
+#  Elixir is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Affero General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Elixir is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Affero General Public License for more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with Elixir.  If not, see <http://www.gnu.org/licenses/>.
+
+from sys import argv
+import re
+import os
+
+usage_message = ("USAGE: find_compatible_dts.py <file> <family>\n"
+                 "file : The file you want to search in\n"
+                 "family : The type of file (C for .c/.cpp/.h/...\n"
+                 "                           D for .dts/.dtsi\n"
+                 "                           B for bindings docs files)")
+
+ident_list = ""
+
+def parse_c(content):
+    return re.findall("\s*{*\s*\.compatible\s*=\s*\"(.+?)\"", content)
+
+def parse_dts(content):
+    ret = []
+    if re.match("\s*compatible", content) != None:
+        ret = re.findall("\"(.+?)\"", content)
+    return ret
+
+def parse_bindings(content):
+    # There are a lot of wrong results
+    # but we don't apply that to a lot of files
+    # so it should be fine
+    return re.findall("([\w-]+,?[\w-]+)", content)
+
+
+# Main
+# Test and get args
+if len(argv) < 3:
+    print("ERROR: Missing arguments !\n" + usage_message)
+    exit(1)
+
+filename = argv[1]
+family = argv[2]
+
+# Make sure it's an accepted family
+if not family in ['C', 'D', 'B']:
+    print("ERROR: Unknown family !\n" + usage_message)
+    exit(1)
+
+# Make sure file exists
+try:
+    f = open(filename, 'r')
+except IOError:
+    print("ERROR: File doesn't exist !\n" + usage_message)
+    exit(1)
+
+# Iterate though lines and search for idents
+for num, line in enumerate(f, 1):
+    if family == 'C':
+        ret = parse_c(line)
+    elif family == 'D':
+        ret = parse_dts(line)
+    elif family == 'B':
+        ret = parse_bindings(line)
+
+    if ret != []:
+        for i in range(len(ret)):
+            ident_list += str(ret[i]) + ' ' + str(num) + '\n'
+
+# Print the list (except the last \n) and exit
+print(ident_list[:-1])
+exit(0)

--- a/find_compatible_dts.py
+++ b/find_compatible_dts.py
@@ -79,11 +79,8 @@ for num, line in enumerate(f, 1):
     elif family == 'B':
         ret = parse_bindings(line)
 
-    if ret != []:
-        for i in range(len(ret)):
-            ident_list += str(parse.quote(ret[i])) + ' ' + str(num) + '\n'
-
-    num += 1
+    for i in range(len(ret)):
+        ident_list += str(parse.quote(ret[i])) + ' ' + str(num) + '\n'
 
 # Print the list and exit
 print(ident_list, end='')

--- a/find_compatible_dts.py
+++ b/find_compatible_dts.py
@@ -22,6 +22,7 @@ from sys import argv
 import re
 import os
 from urllib import parse
+import query
 
 usage_message = ("USAGE: find_compatible_dts.py <file> <family>\n"
                  "file : The file you want to search in\n"
@@ -63,14 +64,14 @@ if not family in ['C', 'D', 'B']:
 
 # Make sure file exists
 try:
-    f = open(filename, 'r')
+    f = open(filename, 'rb')
 except IOError:
     print("ERROR: File doesn't exist !\n" + usage_message)
     exit(1)
 
 # Iterate though lines and search for idents
-num = 1
-for line in f:
+for num, line in enumerate(f, 1):
+    line = query.decode(line)
     if family == 'C':
         ret = parse_c(line)
     elif family == 'D':

--- a/find_compatible_dts.py
+++ b/find_compatible_dts.py
@@ -21,6 +21,7 @@
 from sys import argv
 import re
 import os
+from urllib import parse
 
 usage_message = ("USAGE: find_compatible_dts.py <file> <family>\n"
                  "file : The file you want to search in\n"
@@ -68,7 +69,8 @@ except IOError:
     exit(1)
 
 # Iterate though lines and search for idents
-for num, line in enumerate(f, 1):
+num = 1
+for line in f:
     if family == 'C':
         ret = parse_c(line)
     elif family == 'D':
@@ -78,8 +80,10 @@ for num, line in enumerate(f, 1):
 
     if ret != []:
         for i in range(len(ret)):
-            ident_list += str(ret[i]) + ' ' + str(num) + '\n'
+            ident_list += str(parse.quote(ret[i])) + ' ' + str(num) + '\n'
 
-# Print the list (except the last \n) and exit
-print(ident_list[:-1])
+    num += 1
+
+# Print the list and exit
+print(ident_list, end='')
 exit(0)

--- a/find_compatible_dts.py
+++ b/find_compatible_dts.py
@@ -2,8 +2,8 @@
 
 #  This file is part of Elixir, a source code cross-referencer.
 #
-#  Copyright (C) 2017--2020  Maxime Chretien
-#  <maxime.chretien@bootlin.com> and contributors
+#  Copyright (C) 2017--2020  Maxime Chretien <maxime.chretien@bootlin.com>
+#                            and contributors
 #
 #  Elixir is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU Affero General Public License as published by

--- a/http/filters/common.py
+++ b/http/filters/common.py
@@ -29,3 +29,4 @@ def decode_number(string):
 filters = []
 exec(open('ident.py').read())
 exec(open('cppinc.py').read())
+exec(open('dtscomp.py').read())

--- a/http/filters/common.py
+++ b/http/filters/common.py
@@ -27,6 +27,6 @@ def decode_number(string):
 
 
 filters = []
+exec(open('dtscomp.py').read())
 exec(open('ident.py').read())
 exec(open('cppinc.py').read())
-exec(open('dtscomp.py').read())

--- a/http/filters/dtscomp.py
+++ b/http/filters/dtscomp.py
@@ -1,6 +1,6 @@
 # Elixir Python definitions for DT compatible strings support
 
-if(dts_compatible_string):
+if(dts_comp_support):
     exec(open('dtscompC.py').read())
     exec(open('dtscompD.py').read())
     exec(open('dtscompB.py').read())

--- a/http/filters/dtscomp.py
+++ b/http/filters/dtscomp.py
@@ -1,0 +1,6 @@
+# Elixir Python definitions for DT compatible strings support
+
+if(dts_compatible_string):
+    exec(open('dtscompC.py').read())
+    exec(open('dtscompD.py').read())
+    exec(open('dtscompB.py').read())

--- a/http/filters/dtscompB.py
+++ b/http/filters/dtscompB.py
@@ -1,0 +1,28 @@
+# Filter for DT compatible strings in documentation files
+
+dtscompB = []
+
+def keep_dtscompC(m):
+    text = m.group(1)
+
+    if query('dts-comp-exists', parse.quote(text)):
+        dtscompC.append(text)
+        return '__KEEPDTSCOMPB__' + encode_number(len(dtscompB))
+    else:
+        return m.group(0)
+
+def replace_dtscompB(m):
+    i = dtscompB[decode_number(m.group(1)) - 1]
+
+    return '<a href="'+version+'/B/ident/'+parse.quote(i)+'">'+i+'</a>'
+
+dtscompB_filters = {
+                'case': 'path',
+                'match': {'Documentation/devicetree/bindings'},
+                'prerex': '([\w-]+,?[\w-]+)',
+                'prefunc': keep_dtscompB,
+                'postrex': '__KEEPDTSCOMPB__([A-J]+)',
+                'postfunc': replace_dtscompB
+                }
+
+filters.append(dtscompB_filters)

--- a/http/filters/dtscompB.py
+++ b/http/filters/dtscompB.py
@@ -2,11 +2,11 @@
 
 dtscompB = []
 
-def keep_dtscompC(m):
+def keep_dtscompB(m):
     text = m.group(1)
 
     if query('dts-comp-exists', parse.quote(text)):
-        dtscompC.append(text)
+        dtscompB.append(text)
         return '__KEEPDTSCOMPB__' + encode_number(len(dtscompB))
     else:
         return m.group(0)
@@ -18,7 +18,7 @@ def replace_dtscompB(m):
 
 dtscompB_filters = {
                 'case': 'path',
-                'match': {'Documentation/devicetree/bindings'},
+                'match': {'/Documentation/devicetree/bindings'},
                 'prerex': '([\w-]+,?[\w-]+)',
                 'prefunc': keep_dtscompB,
                 'postrex': '__KEEPDTSCOMPB__([A-J]+)',

--- a/http/filters/dtscompC.py
+++ b/http/filters/dtscompC.py
@@ -3,7 +3,7 @@
 dtscompC = []
 
 def keep_dtscompC(m):
-    dtscompC.append(m.group(2))
+    dtscompC.append(m.group(4))
     return m.group(1) + '"__KEEPDTSCOMPC__' + encode_number(len(dtscompC)) + '"'
 
 def replace_dtscompC(m):
@@ -14,7 +14,7 @@ def replace_dtscompC(m):
 dtscompC_filters = {
                 'case': 'extension',
                 'match': {'c', 'cc', 'cpp', 'c++', 'cxx', 'h', 's'},
-                'prerex': '(\s*{*\s*\.compatible\s*=\s*)\"(.+?)\"',
+                'prerex': '(\s*{*\s*\.(\033\[31m)?compatible(\033\[0m)?\s*=\s*)\"(.+?)\"',
                 'prefunc': keep_dtscompC,
                 'postrex': '__KEEPDTSCOMPC__([A-J]+)',
                 'postfunc': replace_dtscompC

--- a/http/filters/dtscompC.py
+++ b/http/filters/dtscompC.py
@@ -1,0 +1,23 @@
+# Filter for DT compatible strings in C files
+
+dtscompC = []
+
+def keep_dtscompC(m):
+    dtscompC.append(m.group(2))
+    return m.group(1) + '"__KEEPDTSCOMPC__' + encode_number(len(dtscompC)) + '"'
+
+def replace_dtscompC(m):
+    i = dtscompC[decode_number(m.group(1)) - 1]
+
+    return '<a href="'+version+'/B/ident/'+parse.quote(i)+'">'+i+'</a>'
+
+dtscompC_filters = {
+                'case': 'extension',
+                'match': {'c', 'cc', 'cpp', 'c++', 'cxx', 'h', 's'},
+                'prerex': '(\s*{*\s*\.compatible\s*=\s*)\"(.+?)\"',
+                'prefunc': keep_dtscompC,
+                'postrex': '__KEEPDTSCOMPC__([A-J]+)',
+                'postfunc': replace_dtscompC
+                }
+
+filters.append(dtscompC_filters)

--- a/http/filters/dtscompD.py
+++ b/http/filters/dtscompD.py
@@ -1,0 +1,29 @@
+# Filter for DT compatible strings in D files
+
+dtscompD = []
+
+def keep_dtscompD(m):
+    match = m.group(0)
+    strings = re.findall("\"(.+?)\"", m.group(1))
+
+    for string in strings:
+        dtscompD.append(string)
+        match.replace(string, '__KEEPDTSCOMPD__' + encode_number(len(dtscompD)))
+
+    return match
+
+def replace_dtscompD(m):
+    i = dtscompD[decode_number(m.group(1)) - 1]
+
+    return '<a href="'+version+'/B/ident/'+parse.quote(i)+'">'+i+'</a>'
+
+dtscompD_filters = {
+                'case': 'extension',
+                'match': {'dts', 'dtsi'},
+                'prerex': '\s*compatible(.*?)',
+                'prefunc': keep_dtscompD,
+                'postrex': '__KEEPDTSCOMPD__([A-J]+)',
+                'postfunc': replace_dtscompD
+                }
+
+filters.append(dtscompD_filters)

--- a/http/filters/dtscompD.py
+++ b/http/filters/dtscompD.py
@@ -8,7 +8,7 @@ def keep_dtscompD(m):
 
     for string in strings:
         dtscompD.append(string)
-        match.replace(string, '__KEEPDTSCOMPD__' + encode_number(len(dtscompD)))
+        match = match.replace(string, '__KEEPDTSCOMPD__' + encode_number(len(dtscompD)))
 
     return match
 
@@ -20,7 +20,7 @@ def replace_dtscompD(m):
 dtscompD_filters = {
                 'case': 'extension',
                 'match': {'dts', 'dtsi'},
-                'prerex': '\s*compatible(.*?)',
+                'prerex': '\s*compatible(.*?)$',
                 'prefunc': keep_dtscompD,
                 'postrex': '__KEEPDTSCOMPD__([A-J]+)',
                 'postfunc': replace_dtscompD

--- a/http/web.py
+++ b/http/web.py
@@ -330,7 +330,7 @@ elif mode == 'ident':
             print('<h2>Defined in '+str(len(symbol_definitions))+' files:</h2>')
             print('<ul>')
             for symbol_definition in symbol_definitions:
-                ln = symbol_definition.line.split(',')
+                ln = str(symbol_definition.line).split(',')
                 if len(ln) == 1:
                     n = ln[0]
                     print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong>, line {n} <em>(as a {t})</em></a>'.format(

--- a/http/web.py
+++ b/http/web.py
@@ -95,7 +95,7 @@ if m:
             location = '/'+project+'/'+version+'/'+family2+'/ident/'+ident2
         else:
             mode = 'ident'
-            if not(ident and search('^[A-Za-z0-9_-]*$', ident)):
+            if not(ident and search('^[A-Za-z0-9_%-]*$', ident)):
                 ident = ''
             url = family + '/ident/' + ident
     else:
@@ -142,7 +142,7 @@ data = {
     'url': url,
     'project': project,
     'projects': projects,
-    'ident': ident,
+    'ident': parse.unquote(ident),
     'family': search_family,
     'breadcrumb': '<a class="project" href="'+version+'/source">/</a>'
 }
@@ -279,7 +279,10 @@ if mode == 'source':
         # Apply filters
         for f in filters:
             c = f['case']
-            if (c == 'any' or (c == 'filename' and filename in f['match']) or (c == 'extension' and extension in f['match']) or (c == 'path' and fdir.startswith(f['match']))):
+            if (c == 'any' or
+                (c == 'filename' and filename in f['match']) or
+                (c == 'extension' and extension in f['match']) or
+                (c == 'path' and fdir.startswith(tuple(f['match'])))):
 
                 apply_filter = True
 
@@ -306,14 +309,18 @@ if mode == 'source':
 
         for f in filters:
             c = f['case']
-            if (c == 'any' or (c == 'filename' and filename in f['match']) or (c == 'extension' and extension in f['match'])):
+            if (c == 'any' or
+                (c == 'filename' and filename in f['match']) or
+                (c == 'extension' and extension in f['match']) or
+                (c == 'path' and fdir.startswith(tuple(f['match'])))):
+
                 result = sub(f ['postrex'], f ['postfunc'], result)
 
         print('<div class="lxrcode">' + result + '</div>')
 
 
 elif mode == 'ident':
-    data['title'] = ident+' identifier - '+title_suffix
+    data['title'] = parse.unquote(ident)+' identifier - '+title_suffix
 
     symbol_definitions, symbol_references, symbol_doccomments = query('ident', tag, ident, family)
 

--- a/http/web.py
+++ b/http/web.py
@@ -128,6 +128,8 @@ import sys
 sys.path = [ sys.path[0] + '/..' ] + sys.path
 from query import query
 
+dts_comp_support = query('dts-comp')
+
 if version_decoded == 'latest':
     tag = query('latest')
 else:
@@ -259,7 +261,7 @@ if mode == 'source':
         import pygments.lexers
         import pygments.formatters
 
-        fname = os.path.basename(path)
+        fdir, fname = os.path.split(path)
         filename, extension = os.path.splitext(fname)
         extension = extension[1:].lower()
         family = query('family', fname)
@@ -277,7 +279,7 @@ if mode == 'source':
         # Apply filters
         for f in filters:
             c = f['case']
-            if (c == 'any' or (c == 'filename' and filename in f['match']) or (c == 'extension' and extension in f['match'])):
+            if (c == 'any' or (c == 'filename' and filename in f['match']) or (c == 'extension' and extension in f['match']) or (c == 'path' and fdir.startswith(f['match']))):
 
                 apply_filter = True
 

--- a/http/web.py
+++ b/http/web.py
@@ -341,9 +341,28 @@ elif mode == 'ident':
             print('<h2>Documented in '+str(len(symbol_doccomments))+' files:</h2>')
             print('<ul>')
             for symbol_doccomment in symbol_doccomments:
-                print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong>, line {n}</a></li>'.format(
-                    v=version, f=symbol_doccomment.path, n=symbol_doccomment.line
-                ))
+                ln = symbol_doccomment.line.split(',')
+                if len(ln) == 1:
+                    n = ln[0]
+                    print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong>, line {n}</a>'.format(
+                        v=version, f=symbol_doccomment.path, n=n
+                    ))
+                else:
+                    if len(symbol_doccomments) > 100:    # Concise display
+                        n = len(ln)
+                        print('<li><a href="{v}/source/{f}"><strong>{f}</strong>, <em>{n} times</em></a>'.format(
+                            v=version, f=symbol_doccomment.path, n=n
+                        ))
+                    else:    # Verbose display
+                        print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong></a>'.format(
+                            v=version, f=symbol_doccomment.path, n=ln[0]
+                        ))
+                        print('<ul>')
+                        for n in ln:
+                            print('<li><a href="{v}/source/{f}#L{n}">line {n}</a>'.format(
+                                v=version, f=symbol_doccomment.path, n=n
+                            ))
+                        print('</ul>')
             print('</ul>')
 
         if len(symbol_references):

--- a/http/web.py
+++ b/http/web.py
@@ -330,9 +330,28 @@ elif mode == 'ident':
             print('<h2>Defined in '+str(len(symbol_definitions))+' files:</h2>')
             print('<ul>')
             for symbol_definition in symbol_definitions:
-                print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong>, line {n} <em>(as a {t})</em></a>'.format(
-                    v=version, f=symbol_definition.path, n=symbol_definition.line, t=symbol_definition.type
-                ))
+                ln = symbol_definition.line.split(',')
+                if len(ln) == 1:
+                    n = ln[0]
+                    print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong>, line {n} <em>(as a {t})</em></a>'.format(
+                        v=version, f=symbol_definition.path, n=n, t=symbol_definition.type
+                    ))
+                else:
+                    if len(symbol_doccomments) > 100:    # Concise display
+                        n = len(ln)
+                        print('<li><a href="{v}/source/{f}"><strong>{f}</strong>, <em>{n} times</em> <em>(as a {t})</em></a>'.format(
+                            v=version, f=symbol_definition.path, n=n, t=symbol_definition.type
+                        ))
+                    else:    # Verbose display
+                        print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong> <em>(as a {t})</em></a>'.format(
+                            v=version, f=symbol_definition.path, n=ln[0], t=symbol_definition.type
+                        ))
+                        print('<ul>')
+                        for n in ln:
+                            print('<li><a href="{v}/source/{f}#L{n}">line {n}</a>'.format(
+                                v=version, f=symbol_definition.path, n=n
+                            ))
+                        print('</ul>')
             print('</ul>')
         else:
             print('<h2>No definitions found in the database</h2>')

--- a/http/web.py
+++ b/http/web.py
@@ -325,14 +325,17 @@ elif mode == 'ident':
     symbol_definitions, symbol_references, symbol_doccomments = query('ident', tag, ident, family)
 
     print('<div class="lxrident">')
-    if len(symbol_definitions):
-        print('<h2>Defined in '+str(len(symbol_definitions))+' files:</h2>')
-        print('<ul>')
-        for symbol_definition in symbol_definitions:
-            print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong>, line {n} <em>(as a {t})</em></a>'.format(
-                v=version, f=symbol_definition.path, n=symbol_definition.line, t=symbol_definition.type
-            ))
-        print('</ul>')
+    if len(symbol_definitions) or len(symbol_references):
+        if len(symbol_definitions):
+            print('<h2>Defined in '+str(len(symbol_definitions))+' files:</h2>')
+            print('<ul>')
+            for symbol_definition in symbol_definitions:
+                print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong>, line {n} <em>(as a {t})</em></a>'.format(
+                    v=version, f=symbol_definition.path, n=symbol_definition.line, t=symbol_definition.type
+                ))
+            print('</ul>')
+        else:
+            print('<h2>No definitions found in the database</h2>')
 
         if len(symbol_doccomments):
             print('<h2>Documented in '+str(len(symbol_doccomments))+' files:</h2>')
@@ -343,33 +346,35 @@ elif mode == 'ident':
                 ))
             print('</ul>')
 
-
-        print('<h2>Referenced in '+str(len(symbol_references))+' files:</h2>')
-        print('<ul>')
-        for symbol_reference in symbol_references:
-            ln = symbol_reference.line.split(',')
-            if len(ln) == 1:
-                n = ln[0]
-                print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong>, line {n}</a>'.format(
-                    v=version, f=symbol_reference.path, n=n
-                ))
-            else:
-                if len(symbol_references) > 100:    # Concise display
-                    n = len(ln)
-                    print('<li><a href="{v}/source/{f}"><strong>{f}</strong>, <em>{n} times</em></a>'.format(
+        if len(symbol_references):
+            print('<h2>Referenced in '+str(len(symbol_references))+' files:</h2>')
+            print('<ul>')
+            for symbol_reference in symbol_references:
+                ln = symbol_reference.line.split(',')
+                if len(ln) == 1:
+                    n = ln[0]
+                    print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong>, line {n}</a>'.format(
                         v=version, f=symbol_reference.path, n=n
                     ))
-                else:    # Verbose display
-                    print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong></a>'.format(
-                        v=version, f=symbol_reference.path, n=ln[0]
-                    ))
-                    print('<ul>')
-                    for n in ln:
-                        print('<li><a href="{v}/source/{f}#L{n}">line {n}</a>'.format(
+                else:
+                    if len(symbol_references) > 100:    # Concise display
+                        n = len(ln)
+                        print('<li><a href="{v}/source/{f}"><strong>{f}</strong>, <em>{n} times</em></a>'.format(
                             v=version, f=symbol_reference.path, n=n
                         ))
-                    print('</ul>')
-        print('</ul>')
+                    else:    # Verbose display
+                        print('<li><a href="{v}/source/{f}#L{n}"><strong>{f}</strong></a>'.format(
+                            v=version, f=symbol_reference.path, n=ln[0]
+                        ))
+                        print('<ul>')
+                        for n in ln:
+                            print('<li><a href="{v}/source/{f}#L{n}">line {n}</a>'.format(
+                                v=version, f=symbol_reference.path, n=n
+                            ))
+                        print('</ul>')
+            print('</ul>')
+        else:
+            print('<h2>No references found in the database</h2>')
     else:
         if ident != '':
             print('<h2>Identifier not used</h2>')

--- a/projects/arm-trusted-firmware.sh
+++ b/projects/arm-trusted-firmware.sh
@@ -1,6 +1,9 @@
 # Elixir definitions for Arm Trusted Firmware
 # https://github.com/ARM-software/arm-trusted-firmware
 
+# Enable DT bindings compatible strings support
+dts_comp_support=1
+
 list_tags_h()
 {
     echo "$tags" |

--- a/projects/barebox.sh
+++ b/projects/barebox.sh
@@ -1,5 +1,8 @@
 # Elixir definitions for Barebox
 
+# Enable DT bindings compatible strings support
+dts_comp_support=1
+
 list_tags_h()
 {
     echo "$tags" |

--- a/projects/linux.sh
+++ b/projects/linux.sh
@@ -1,5 +1,8 @@
 # Elixir definitions for Linux
 
+# Enable DT bindings compatible strings support
+dts_comp_support=1
+
 get_tags()
 {
     git tag |

--- a/projects/u-boot.sh
+++ b/projects/u-boot.sh
@@ -1,5 +1,8 @@
 # Elixir definitions for U-Boot
 
+# Enable DT bindings compatible strings support
+dts_comp_support=1
+
 list_tags_h()
 {
     echo "$tags" |

--- a/projects/zephyr.sh
+++ b/projects/zephyr.sh
@@ -1,5 +1,8 @@
 # Elixir definitions for Zephyr
 
+# Enable DT bindings compatible strings support
+dts_comp_support=1
+
 list_tags()
 {
     echo "$tags" |

--- a/query.py
+++ b/query.py
@@ -216,8 +216,10 @@ def query(cmd, *args):
 
             files_this_version = db.vers.get(version).iter()
             comps = db.comps.get(ident).iter(dummy=True)
+            comps_docs = db.comps_docs.get(ident).iter(dummy=True)
 
             comps_idx, comps_lines, comps_family = next(comps)
+            comps_docs_idx, comps_docs_lines, comps_docs_family = next(comps_docs)
             compsCBuf = [] # C/CPP/ASM files
             compsDBuf = [] # DT files
             compsBBuf = [] # DT bindings docs files
@@ -225,15 +227,20 @@ def query(cmd, *args):
             for file_idx, file_path in files_this_version:
                 while comps_idx < file_idx:
                     comps_idx, comps_lines, comps_family = next(comps)
+
+                while comps_docs_idx < file_idx:
+                    comps_docs_idx, comps_docs_lines, comps_docs_family = next(comps_docs)
+
                 while comps_idx == file_idx:
                     if comps_family == 'C':
                         compsCBuf.append((file_path, comps_lines))
                     elif comps_family == 'D':
                         compsDBuf.append((file_path, comps_lines))
-                    elif comps_family == 'B':
-                        compsBBuf.append((file_path, comps_lines))
-
                     comps_idx, comps_lines, comps_family = next(comps)
+
+                while comps_docs_idx == file_idx:
+                    compsBBuf.append((file_path, comps_docs_lines))
+                    comps_docs_idx, comps_docs_lines, comps_docs_family = next(comps_docs)
 
             for path, cline in sorted(compsCBuf):
                 symbol_definitions.append(SymbolInstance(path, cline, 'compatible'))

--- a/query.py
+++ b/query.py
@@ -231,16 +231,14 @@ def query(cmd, *args):
                 while comps_docs_idx < file_idx:
                     comps_docs_idx, comps_docs_lines, comps_docs_family = next(comps_docs)
 
-                while comps_idx == file_idx:
+                if comps_idx == file_idx:
                     if comps_family == 'C':
                         compsCBuf.append((file_path, comps_lines))
                     elif comps_family == 'D':
                         compsDBuf.append((file_path, comps_lines))
-                    comps_idx, comps_lines, comps_family = next(comps)
 
-                while comps_docs_idx == file_idx:
+                if comps_docs_idx == file_idx:
                     compsBBuf.append((file_path, comps_docs_lines))
-                    comps_docs_idx, comps_docs_lines, comps_docs_family = next(comps_docs)
 
             for path, cline in sorted(compsCBuf):
                 symbol_definitions.append(SymbolInstance(path, cline, 'compatible'))
@@ -248,8 +246,8 @@ def query(cmd, *args):
             for path, dlines in sorted(compsDBuf):
                 symbol_references.append(SymbolInstance(path, dlines))
 
-            for path, bline in sorted(compsBBuf):
-                symbol_doccomments.append(SymbolInstance(path, bline))
+            for path, blines in sorted(compsBBuf):
+                symbol_doccomments.append(SymbolInstance(path, blines))
 
             return symbol_definitions, symbol_references, symbol_doccomments
 

--- a/query.py
+++ b/query.py
@@ -233,8 +233,10 @@ def query(cmd, *args):
                     elif comps_family == 'B':
                         compsBBuf.append((file_path, comps_lines))
 
-            for path, type, cline in sorted(compsCBuf):
-                symbol_definitions.append(SymbolInstance(path, cline))
+                    comps_idx, comps_lines, comps_family = next(comps)
+
+            for path, cline in sorted(compsCBuf):
+                symbol_definitions.append(SymbolInstance(path, cline, 'compatible'))
 
             for path, dlines in sorted(compsDBuf):
                 symbol_references.append(SymbolInstance(path, dlines))

--- a/query.py
+++ b/query.py
@@ -24,7 +24,9 @@ import data
 import os
 from collections import OrderedDict
 
-db = data.DB(lib.getDataDir(), readonly=True)
+dts_comp_support = int(script('dts-comp'))
+
+db = data.DB(lib.getDataDir(), readonly=True, dtscomp=dts_comp_support)
 
 from io import BytesIO
 
@@ -181,14 +183,16 @@ def query(cmd, *args):
     elif cmd == 'dts-comp':
         # Get state of dts_comp_support
 
-        return script('comp-dts')
+        return dts_comp_support
 
     elif cmd == 'dts-comp-exists':
         # Check if a dts compatible string exists
 
         ident = args[0]
-
-        return db.comps.exists(ident)
+        if dts_comp_support:
+            return db.comps.exists(ident)
+        else:
+            return False
 
     elif cmd == 'ident':
 
@@ -207,7 +211,7 @@ def query(cmd, *args):
         # Used in DT files
         # Documented in documentation files
         if family == 'B':
-            if not db.comps.exists(ident):
+            if not dts_comp_support or not db.comps.exists(ident):
                 return symbol_definitions, symbol_references, symbol_doccomments
 
             files_this_version = db.vers.get(version).iter()

--- a/query.py
+++ b/query.py
@@ -216,7 +216,11 @@ def query(cmd, *args):
 
             files_this_version = db.vers.get(version).iter()
             comps = db.comps.get(ident).iter(dummy=True)
-            comps_docs = db.comps_docs.get(ident).iter(dummy=True)
+
+            if db.comps_docs.exists(ident):
+                comps_docs = db.comps_docs.get(ident).iter(dummy=True)
+            else:
+                comps_docs = data.RefList().iter(dummy=True)
 
             comps_idx, comps_lines, comps_family = next(comps)
             comps_docs_idx, comps_docs_lines, comps_docs_family = next(comps_docs)

--- a/script.sh
+++ b/script.sh
@@ -30,6 +30,7 @@ script_path=`realpath "$0"`
 cd `dirname "$script_path"`
 script_dir=`pwd`
 cd "$cur_dir"
+dts_comp_support=0 # DT bindings compatible strings support (disable by default)
 
 version_dir()
 {
@@ -207,6 +208,21 @@ parse_docs()
     rm -rf "$tmpfile"
 }
 
+parse_comps()
+{
+    tmpfile=`mktemp`
+
+    git cat-file blob "$opt1" > "$tmpfile"
+    "$script_dir/find_compatible_dts.py" "$tmpfile" "$opt3" || exit "$?"
+
+    rm -rf "$tmpfile"
+}
+
+dts_comp()
+{
+    echo $dts_comp_support
+}
+
 project=$(basename `dirname $LXR_REPO_DIR`)
 
 plugin=$script_dir/projects/$project.sh
@@ -278,6 +294,14 @@ case $cmd in
 
     parse-docs)
         parse_docs
+        ;;
+
+    parse-comps)
+        parse_comps
+        ;;
+
+    dts-comp)
+        dts_comp
         ;;
 
     help)

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -25,10 +25,11 @@
                 <div class="search">
                     <form  method="post" action="{{version}}/ident">
                         <select name="f" title="Restricts search to specific file families">
-                            <option value="A" {% if family=="A" %} selected="selected"{% endif %}>All</option>
+                            <option value="A" {% if family=="A" %} selected="selected"{% endif %}>All symbols</option>
                             <option value="C" {% if family=="C" %} selected="selected"{% endif %}>C/CPP/ASM</option>
                             <option value="K" {% if family=="K" %} selected="selected"{% endif %}>Kconfig</option>
                             <option value="D" {% if family=="D" %} selected="selected"{% endif %}>Devicetree</option>
+                            <option value="B" {% if family=="B" %} selected="selected"{% endif %}>DT compatible</option>
                         </select>
 
                         <input placeholder="Search Identifier" type="text" name="i" value="{{ident}}"/>

--- a/update.py
+++ b/update.py
@@ -544,8 +544,8 @@ project = lib.currentProject()
 
 print(project + ' - found ' + str(len(tag_buf)) + ' new tags')
 
-ids_thread = UpdateIds(tag_buf)
-versions_thread = UpdateVersions(tag_buf)
+threads_list.append(UpdateIds(tag_buf))
+threads_list.append(UpdateVersions(tag_buf))
 
 # Define defs threads
 for i in range(num_th_defs):
@@ -565,19 +565,16 @@ for i in range(num_th_comps_docs):
 
 
 # Start to process tags
-ids_thread.start()
+threads_list[0].start()
 
 # Wait until the first tag is ready
 with tag_ready:
     tag_ready.wait()
 
 # Start remaining threads
-versions_thread.start()
-for i in range(len(threads_list)):
+for i in range(1, len(threads_list)):
     threads_list[i].start()
 
 # Make sure all threads finished
-ids_thread.join()
-versions_thread.join()
 for i in range(len(threads_list)):
     threads_list[i].join()

--- a/update.py
+++ b/update.py
@@ -136,7 +136,7 @@ class UpdateIdVersion(Thread):
             obj.append(idx, path)
 
             # Store DT bindings documentation files to parse them later
-            if path[:33] == 'Documentation/devicetree/bindings':
+            if path[:33] == b'Documentation/devicetree/bindings':
                 bindings_idxes.append(idx)
 
             if verbose:
@@ -396,7 +396,7 @@ class UpdateComps(Thread):
         global hash_file_lock, comps_lock, tags_comps, bindings_idxes
 
         for idx in idxes:
-            if (idx % 1000 == 0): progress('comps: ' + str(idx) + ' 2/2', tags_comp)
+            if (idx % 1000 == 0): progress('comps: ' + str(idx) + ' 2/2', tags_comps)
 
             if not idx in bindings_idxes: # Parse only bindings doc files
                 continue

--- a/update.py
+++ b/update.py
@@ -377,17 +377,24 @@ class UpdateComps(Thread):
             if family in [None, 'K']: continue
 
             lines = scriptLines('parse-comps', hash, filename, family)
-            with comps_lock:
-                for l in lines:
-                    ident, line = l.split(b' ')
-                    line = int(line.decode())
+            comps = {}
+            for l in lines:
+                ident, line = l.split(b' ')
+                line = line.decode()
 
+                if ident in comps:
+                    comps[ident] += ',' + str(line)
+                else:
+                    comps[ident] = str(line)
+
+            with comps_lock:
+                for ident, lines in comps.items():
                     if db.comps.exists(ident):
                         obj = db.comps.get(ident)
                     else:
                         obj = data.RefList()
 
-                    obj.append(idx, str(line), family)
+                    obj.append(idx, lines, family)
                     if verbose:
                         print(f"comps: {ident} in #{idx} @ {line}")
                     db.comps.put(ident, obj)

--- a/update.py
+++ b/update.py
@@ -32,7 +32,9 @@ from threading import Thread, Lock, Event, Condition
 
 verbose = False
 
-db = data.DB(lib.getDataDir(), readonly=False)
+dts_comp_support = int(script('dts-comp'))
+
+db = data.DB(lib.getDataDir(), readonly=False, dtscomp=dts_comp_support)
 
 # Number of cpu threads (+1 for version indexing)
 cpu = 8
@@ -445,7 +447,7 @@ num_th_docs = quo
 
 # If DT bindings support is enabled, use $quo threads for that
 # Otherwise add them to the remaining threads
-if int(script('dts-comp')):
+if dts_comp_support:
     num_th_comps = quo
 else :
     num_th_comps = 0


### PR DESCRIPTION
This implement https://github.com/bootlin/elixir/issues/144

Short log : 
- Add a python script to search DT compatibles in different type of files
- Add 2 new databases, one to index where DT compatibles are defined and used and another to index where they are documented
- Add a special handling in query('ident',..) for DT compatibles
- Use web.py ident page to display DT compatibles, "Define in" for C files, "Documented in" for documentations and "Referenced in" for DT files
- Improve web.py to show references even if there is no definition (because of a missing element in the database or a DT compatible not listed in a C file but only in a DT file)
- Add special filters for DT compatibles
- Add a 'DT compatible' option to search for compatible strings (they are not listed in "All symbols")
- Add an option to enable DT compatible support only for projects who need it (disabled by default)
- Update API to support DT compatibles
- Improve update.py parallel execution