### PR TITLE
update.py: Exit if there is no tag to add

### DIFF
--- a/update.py
+++ b/update.py
@@ -545,7 +545,10 @@ for tag in scriptLines('list-tags'):
 num_tags = len(tag_buf)
 project = lib.currentProject()
 
-print(project + ' - found ' + str(len(tag_buf)) + ' new tags')
+print(project + ' - found ' + str(num_tags) + ' new tags')
+
+if not num_tags:
+    exit(0)
 
 threads_list.append(UpdateIds(tag_buf))
 threads_list.append(UpdateVersions(tag_buf))


### PR DESCRIPTION
This prevent the script from locking at line 578 because UpdateIds will never send an event to wake up the threads (line 91) if there is no tag to add. (Solves https://github.com/bootlin/elixir/issues/155)

Also change len(tag_buf) to num_tags in line 548, no need to compute the
length again as we already have it.