### PR TITLE
queries: Support C macros in DT files

### DIFF
--- a/data.py
+++ b/data.py
@@ -27,6 +27,7 @@ import os.path
 import errno
 
 deflist_regex = re.compile(b'(\d*)(\w)(\d*)(\w),?')
+deflist_macro_regex = re.compile('\dM\d+(\w)')
 
 ##################################################################################
 
@@ -93,6 +94,9 @@ class DefList:
 
     def get_families(self):
         return self.families.decode().split(',')
+
+    def get_macros(self):
+        return deflist_macro_regex.findall(self.data.decode()) or ''
 
 class PathList:
     '''Stores associations between a blob ID and a file path.

--- a/lib.py
+++ b/lib.py
@@ -210,10 +210,12 @@ def getFileFamily(filename):
     else :
         return None
 
+# 1 char values are file families
+# 2 chars values with a M are macros families
 compatibility_list = {
     'C' : ['C', 'K'],
     'K' : ['K'],
-    'D' : ['D']
+    'D' : ['D', 'CM']
 }
 
 # Check if families are compatible
@@ -221,3 +223,13 @@ compatibility_list = {
 # Second argument is the key for chossing the right array in the compatibility list
 def compatibleFamily(file_family, requested_family):
     return any(item in file_family for item in compatibility_list[requested_family])
+
+# Check if a macro is compatible with the requested family
+# First argument can be a list of different families
+# Second argument is the key for chossing the right array in the compatibility list
+def compatibleMacro(macro_family, requested_family):
+    result = False
+    for item in macro_family:
+        item += 'M'
+        result = result or item in compatibility_list[requested_family]
+    return result

--- a/query.py
+++ b/query.py
@@ -157,7 +157,8 @@ def query(cmd, *args):
                 even = not even
                 tok2 = prefix + tok
                 if (even and db.defs.exists(tok2) and
-                    lib.compatibleFamily(db.defs.get(tok2).get_families(), family)):
+                    (lib.compatibleFamily(db.defs.get(tok2).get_families(), family) or
+                    lib.compatibleMacro(db.defs.get(tok2).get_macros(), family))):
                     tok = b'\033[31m' + tok2 + b'\033[0m'
                 else:
                     tok = lib.unescape(tok)
@@ -302,7 +303,9 @@ def get_idents_defs(version, ident, family):
         return symbol_definitions, symbol_references, symbol_doccomments
 
     files_this_version = db.vers.get(version).iter()
-    defs_this_ident = db.defs.get(ident).iter(dummy=True)
+    this_ident = db.defs.get(ident)
+    defs_this_ident = this_ident.iter(dummy=True)
+    macros_this_ident = this_ident.get_macros()
     # FIXME: see why we can have a discrepancy between defs_this_ident and refs
     if db.refs.exists(ident):
         refs = db.refs.get(ident).iter(dummy=True)
@@ -338,7 +341,8 @@ def get_idents_defs(version, ident, family):
 
         # Copy information about this identifier into dBuf, rBuf, and docBuf.
         while def_idx == file_idx:
-            if def_family == family or family == 'A':
+            if (def_family == family or family == 'A'
+                or lib.compatibleMacro(macros_this_ident, family)):
                 dBuf.append((file_path, def_type, def_line))
             def_idx, def_type, def_line, def_family = next(defs_this_ident)
 


### PR DESCRIPTION
Add a new data and a new lib functions to get the families of a macro and test if it's compatible or not with the requested family.

This doesn't require a new database it only uses the values already present in the database.

This implement https://github.com/bootlin/elixir/issues/145