### PR TITLE
Shrink ".hilight a" background color

### DIFF
--- a/http/style.css
+++ b/http/style.css
@@ -732,9 +732,7 @@ h2 {
 .highlight a {
   color: inherit;
   font-weight: 700;
-  background-color: #f4f6ff;
-  -webkit-box-shadow: 0 0 0 1px #f4f6ff;
-          box-shadow: 0 0 0 1px #f4f6ff;
+  background: linear-gradient(to bottom, #0000 10%, #f4f6ff 10%, #f4f6ff 90%, #0000 90%);
   border-radius: 0.2em;
 }
 .highlight a:hover {


### PR DESCRIPTION
On some screens / fonts, the link background color is too thick and it hides features of the line above

Before:
![immagine](https://user-images.githubusercontent.com/3357750/93525315-20ad4d00-f936-11ea-94fc-048dad51932b.png)


After:
![immagine](https://user-images.githubusercontent.com/3357750/93525345-2efb6900-f936-11ea-8150-551ebe41792d.png)


