### PR TITLE
Fix a misspelling with the path used to store elixir-data

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -167,7 +167,7 @@ And then run `source /etc/profile`.
 First clone the master tree released by Linus Torvalds:
 
 ----
-cd /pathy/elixir-data/linux
+cd /path/elixir-data/linux
 git clone https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git repo
 ----
 


### PR DESCRIPTION
This PR corrects a small misspelling in the project README. 

Thanks for all of your hard work with elixir!