### PR TITLE
Extract documentation even if a symbol has multiple definitions in the same file (#186)

### DIFF
--- a/t/300-doc-comments.t
+++ b/t/300-doc-comments.t
@@ -170,4 +170,23 @@ run_produces_ok('No warnings on macro, #186',
     [ ],
     MUST_SUCCEED);  # warnings appear on stderr, failing the MUST_SUCCEED checks
 
+# #186 counterexamples
+run_produces_ok('ident query (existent, documented as function), #186 counterexample',
+    [$tenv->query_py, qw(v5.4 ident i186c_fn1 C)],
+    [
+        qr{^Documented in:},
+        {doc => qr{\bissue186-counterexamples\.c.+\b5\b}},
+    ],
+    MUST_SUCCEED);
+
+run_produces_ok('ident query (existent, documented as macro), #186 counterexample',
+    [$tenv->query_py, qw(v5.4 ident i186c_fn2 C)],
+    [
+        qr{^Documented in:},
+        {doc => qr{\bissue186-counterexamples\.c.+\b20\b}},
+    ],
+    MUST_SUCCEED);
+
+#########################################################################
+
 done_testing;

--- a/t/300-doc-comments.t
+++ b/t/300-doc-comments.t
@@ -27,6 +27,7 @@ use autodie;    # note: still need to check system() calls manually
 use FindBin '$Bin';
 use lib $Bin;
 
+use File::Spec;
 use Test::More;
 
 use TestEnvironment;
@@ -162,5 +163,11 @@ run_produces_ok('ident query (existent, prototype, documented in C file), #134',
         {doc => qr{\bissue134\.c.+\b38\b}},
     ],
     MUST_SUCCEED);
+
+# #186
+run_produces_ok('No warnings on macro, #186',
+    [$tenv->find_doc, File::Spec->catfile($tenv->lxr_repo_dir, 'issue186.c')],
+    [ ],
+    MUST_SUCCEED);  # warnings appear on stderr, failing the MUST_SUCCEED checks
 
 done_testing;

--- a/t/TestEnvironment.pm
+++ b/t/TestEnvironment.pm
@@ -53,7 +53,7 @@ use constant PROJECT => 'testproj';
 
 =head2 lxr_proj_dir
 
-C<$lxr_proj_dir> is the value to use in the C<LXR_DATA_DIR> environment
+C<$lxr_proj_dir> is the value to use in the C<LXR_PROJ_DIR> environment
 variable.
 
 =head2 lxr_data_dir

--- a/t/tree/issue186-counterexamples.c
+++ b/t/tree/issue186-counterexamples.c
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: CC0-1.0
+// This file is the situation of #186, but with documentation.
+
+#ifdef SOMETHING
+/**
+ * i186c_fn1 - do something
+ */
+static int i186c_fn1(struct platform_device *pdev)
+{
+}
+#else
+#define i186c_fn1	NULL
+#endif
+
+#ifdef SOMETHING
+static int i186c_fn2(struct platform_device *pdev)
+{
+}
+#else
+/**
+ * i186c_fn2 - do something
+ */
+#define i186c_fn2	NULL
+#endif

--- a/t/tree/issue186.c
+++ b/t/tree/issue186.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: CC0-1.0
+// This file triggers the bug described in #186.
+
+#ifdef SOMETHING
+static int undocumented_function(struct platform_device *pdev)
+{
+}
+
+#else
+#define undocumented_function	NULL
+#endif


### PR DESCRIPTION
The root cause of #186 was that find-file-doc-comments.pl was not properly checking symbols defined as a macro on one line of a file and as a function earlier in that file.  This PR:

- Adds tests of that situation, both for undocumented symbols (the failure mode in #186) and for documented symbols (for completeness)
- Modifies find-file-doc-comments.pl to always index by line, never by name, so it won't matter if a name is defined multiple times in one file 
- Cleans up verbose output in find-file-doc-comments.pl (but no substantive changes to that output)
- Fixes a typo

Thanks for considering this PR!