### PR TITLE
Doc comments: support indented #defines; report filename on warnings

### DIFF
--- a/find-file-doc-comments.pl
+++ b/find-file-doc-comments.pl
@@ -22,7 +22,7 @@
 
 use 5.010001;
 use strict;
-use warnings FATAL => qw(uninitialized);
+use warnings;
 use autodie;
 
 my $VERBOSE = $ENV{V};
@@ -31,10 +31,16 @@ exit main(@ARGV);
 
 sub main {
     die "Need a filename" unless @_;
-    say "Processing file $_[0]" if $VERBOSE;
+    my $filename = shift;
+    say "Processing file $filename" if $VERBOSE;
+
+    # Fatalize all warnings, and log which file triggered the warning.
+    local $SIG{__WARN__} = sub {
+        die "While processing $filename: $_[0]\n";
+    };
 
     # Do `script.sh parse-defs` on the file
-    my @ctags = qx{ ctags -x --c-kinds=+p-m --language-force=C "$_[0]" |
+    my @ctags = qx{ ctags -x --c-kinds=+p-m --language-force=C "$filename" |
             grep -av "^operator " |
             awk '{print \$1" "\$2" "\$3}' };
     die "Could not get ctags: $!" if $!;
@@ -60,7 +66,7 @@ sub main {
     }
 
     # Read the source file
-    open my $fh, '<', $_[0];
+    open my $fh, '<', $filename;
     my @source_lines = (undef, <$fh>);
         # undef => indices in @source_lines match ctags's 1-based linenos
     close $fh;

--- a/find-file-doc-comments.pl
+++ b/find-file-doc-comments.pl
@@ -86,7 +86,7 @@ sub main {
 
         if($definition_type eq 'macro') {
             # Make sure we get back past the first line of a multiline macro
-            --$lineno while $lineno && $source_lines[$lineno] !~ /^#\h*define/;
+            --$lineno while $lineno && $source_lines[$lineno] !~ /^\h*#\h*define/;
         }
 
         # Assume cflags gave us the first line of the definition, or we got

--- a/t/300-doc-comments.t
+++ b/t/300-doc-comments.t
@@ -187,6 +187,12 @@ run_produces_ok('ident query (existent, documented as macro), #186 counterexampl
     ],
     MUST_SUCCEED);
 
+# #188
+run_produces_ok('No warnings on indented #define, #188',
+    [$tenv->find_doc, File::Spec->catfile($tenv->lxr_repo_dir, 'issue188.c')],
+    [ ],
+    MUST_SUCCEED);  # warnings appear on stderr, failing the MUST_SUCCEED checks
+
 #########################################################################
 
 done_testing;

--- a/t/tree/issue188.c
+++ b/t/tree/issue188.c
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: CC0-1.0
+// This file triggers the bug described in #188.
+
+static int undocumented_function(struct platform_device *pdev)
+{
+    int foo;
+    #define BAR (42)
+    foo=1;
+    return foo;
+}


### PR DESCRIPTION
Fixes #188.

- Support code like

      void foo() {
            #define whatever
      }

- On warning, report the name of the file that triggered it.