### PR TITLE
docker: Execute update.py with unbuffered output

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -65,7 +65,7 @@ ENV LXR_DATA_DIR /srv/elixir-data/$PROJECT/data
 RUN \
   cd /usr/local/elixir/ && \
   ./script.sh list-tags && \
-  ./update.py
+  python3 -u ./update.py
 
 # apache elixir config, see elixir README
 # apache HttpProtolOptions workaround

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -57,7 +57,7 @@ ENV LXR_DATA_DIR /srv/elixir-data/$PROJECT/data
 RUN \
   cd /usr/local/elixir/ && \
   ./script.sh list-tags && \
-  ./update.py
+  python3 -u ./update.py
 
 # apache elixir config, see elixir README
 # make apache less stricter about cgitb spam headers


### PR DESCRIPTION
This allows to have real time logging while building the database.

Without that you have to wait for the end of the script to get the output which can be really long for some projects.