### PR TITLE
query: Sort definitions by type

### DIFF
--- a/query.py
+++ b/query.py
@@ -353,8 +353,10 @@ def get_idents_defs(version, ident, family):
         if doc_idx == file_idx: # TODO should this be a `while`?
             docBuf.append((file_path, doc_line))
 
+    # Sort dBuf by path name before sorting by type in the loop
+    dBuf.sort()
 
-    for path, type, dline in sorted(dBuf):
+    for path, type, dline in sorted(dBuf, key=lambda d: d[1], reverse=True):
         symbol_definitions.append(SymbolInstance(path, dline, type))
 
     for path, rlines in sorted(rBuf):

--- a/t/api_test.py
+++ b/t/api_test.py
@@ -57,9 +57,9 @@ class APITest(testing.TestCase):
         expected_json = {
             'definitions':
             [
+                {'path': 'include/linux/i2c.h', 'line': 941, 'type': 'prototype'},
                 {'path': 'drivers/i2c/i2c-core-of.c', 'line': 22, 'type': 'function'},
-                {'path': 'include/linux/i2c.h', 'line': 968, 'type': 'function'},
-                {'path': 'include/linux/i2c.h', 'line': 941, 'type': 'prototype'}
+                {'path': 'include/linux/i2c.h', 'line': 968, 'type': 'function'}
             ],
             'references':
                 [


### PR DESCRIPTION
This sorts the definition buffer by file path and then by type (reversed).

Sorting by type in reverse order allows to have structs definitions before members.

This solves issue https://github.com/bootlin/elixir/issues/189

As a side effect it also lists functions prototypes before functions implementations which is a good thing I guess.