### PR TITLE
find-file-doc-comments: Handle "type\nname" definitions

### DIFF
--- a/find-file-doc-comments.pl
+++ b/find-file-doc-comments.pl
@@ -90,9 +90,14 @@ sub main {
             qr{^$comment_leader\Q$definition_name\E(?:\h|\(|:|$)};
         say "  Regex is -$this_doc_comment_header-" if $VERBOSE;
 
+        # Make sure we get back past the first line of multiline definitions
         if($definition_type eq 'macro') {
-            # Make sure we get back past the first line of a multiline macro
             --$lineno while $lineno && $source_lines[$lineno] !~ /^\h*#\h*define/;
+        } elsif($definition_type eq 'function') {
+            # Try to handle the case of "int\nfoo()"
+            if($source_lines[$lineno] =~ /^\h*\Q$definition_name\E\b/) {
+                --$lineno while $lineno && $source_lines[$lineno] =~ /^[a-z_]/i;
+            }
         }
 
         # Assume cflags gave us the first line of the definition, or we got
@@ -135,7 +140,7 @@ sub main {
 
         # We have found a doc comment for this function!  Record it.
         push @{$doc_comments{$definition_name}}, $lineno;
-    }
+    } # foreach line in reverse order
 
     # Report the doc comments for each function
     for my $definition_name (keys %doc_comments) {
@@ -144,4 +149,4 @@ sub main {
     }
 
     return 0;
-}
+} #main

--- a/t/300-doc-comments.t
+++ b/t/300-doc-comments.t
@@ -193,6 +193,25 @@ run_produces_ok('No warnings on indented #define, #188',
     [ ],
     MUST_SUCCEED);  # warnings appear on stderr, failing the MUST_SUCCEED checks
 
+# #192
+
+# Like request_firmware()
+run_produces_ok('ident query (existent, function, documented in C file, type on preceding line, #192)',
+    [$tenv->query_py, qw(v5.4 ident issue192a C)],
+    [
+        qr{^Documented in:},
+        {doc => qr{\bissue192\.c.+\b5\b}},
+    ],
+    MUST_SUCCEED);
+
+run_produces_ok('ident query (existent, function, documented in C file, uppercase return type on preceding line, #192)',
+    [$tenv->query_py, qw(v5.4 ident issue192b C)],
+    [
+        qr{^Documented in:},
+        {doc => qr{\bissue192\.c.+\b15\b}},
+    ],
+    MUST_SUCCEED);
+
 #########################################################################
 
 done_testing;

--- a/t/300-doc-comments.t
+++ b/t/300-doc-comments.t
@@ -127,14 +127,6 @@ run_produces_ok('ident query (existent, macro, not documented)',
     ],
     MUST_SUCCEED);
 
-run_produces_ok('ident query (existent, macro, not documented)',
-    [$tenv->query_py, qw(v5.4 ident MEMBLOCK_LOW_LIMIT C)], # memblock.h:343
-    [
-        qr{^Documented in:},
-        {doc => { not => qr{/} }}
-    ],
-    MUST_SUCCEED);
-
 # Specific cases from #134
 
 # Like regmap_update_bits_base()

--- a/t/tree/issue192.c
+++ b/t/tree/issue192.c
@@ -1,0 +1,24 @@
+/* t/tree/issue192.c */
+/* SPDX-License-Identifier: CC0-1.0 */
+/* This file triggers the bug described in #192. */
+
+/**
+ * issue192a: - do something
+ **/
+int
+issue192a(const struct foo **bar, const char *bat,
+         struct baz *quux)
+{
+    return 0;
+}
+
+/**
+ * issue192b()
+ *
+ * Allow an uppercase return type
+ */
+AMAZING_RETURN_TYPE
+issue192b(void *parameter)
+{
+    return (AMAZING_RETURN_TYPE)31337;
+}


### PR DESCRIPTION
Fixes #192.

Previously, find-file-doc-comments could handle

    int foo() {}

but not

    int
    foo() {}

When processing a function, if the reported line begins with the function's symbol, assume we have the latter situation.  Move backward to the first line that doesn't start with an ASCII letter.  This is my best current guess as to a reasonable heuristic.

Additionally, remove an extra copy of one of our tests --- we were running the same test twice in a row! :)

Thank you for considering this PR!