### PR TITLE
Fix tests in docker

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -35,13 +35,18 @@ RUN \
     perl-autodie \
     jansson \
     libyaml \
-    git \
+    rh-git218 \
     wget \
     perl-Test-Most
     # httpd & perl is inherited from upstream openshift image
 
 RUN \
   ln -s /usr/bin/pytest-3 /usr/bin/pytest
+
+RUN \
+  ln -s /opt/rh/rh-git218/root/usr/bin/* /usr/bin/ && \
+  ln -s /opt/rh/rh-git218/root/usr/share/perl5/vendor_perl/* /usr/share/perl5/vendor_perl/ && \
+  ln -s /opt/rh/httpd24/root/usr/lib64/lib* /usr/lib64/
 
 RUN \
   wget https://bootlin.com/pub/elixir/universal-ctags-0+git~20e934e3-1.6.x86_64.rpm

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -36,8 +36,12 @@ RUN \
     jansson \
     libyaml \
     git \
-    wget
+    wget \
+    perl-Test-Most
     # httpd & perl is inherited from upstream openshift image
+
+RUN \
+  ln -s /usr/bin/pytest-3 /usr/bin/pytest
 
 RUN \
   wget https://bootlin.com/pub/elixir/universal-ctags-0+git~20e934e3-1.6.x86_64.rpm
@@ -50,6 +54,10 @@ RUN \
 
 RUN \
   pip3 install Pygments-2.6.1.elixir-py3-none-any.whl
+
+RUN \
+  git config --global user.email 'elixir@dummy.com' && \
+  git config --global user.name 'elixir'
 
 RUN \
   git clone https://github.com/bootlin/elixir.git /usr/local/elixir/

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -29,6 +29,9 @@ RUN \
     wget
 
 RUN \
+  ln -s /usr/bin/pytest-3 /usr/bin/pytest
+
+RUN \
   wget https://bootlin.com/pub/elixir/universal-ctags_0+git20200526-0ubuntu1_amd64.deb
 
 RUN \
@@ -39,6 +42,10 @@ RUN \
 
 RUN \
   pip3 install Pygments-2.6.1.elixir-py3-none-any.whl
+
+RUN \
+  git config --global user.email 'elixir@dummy.com' && \
+  git config --global user.name 'elixir'
 
 RUN \
   git clone https://github.com/bootlin/elixir.git /usr/local/elixir/


### PR DESCRIPTION
Tests are not working in docker for now.

There are multiple issues here.

List of fixed issues for now :
- python3-pytest creates a pytest-3 executable (instead of pytest) so prove can't launch it properly (fixed by a symbolic link)
- git was not configured to create commits (fixed with dummy config)
- some perl packages for tests were missing in centos docker
- git version in centos 7 was too old for the commands used in tests (-C parameter) (fixed by using rh-git218 and creating symlinks to use it as git)

List of remaining issues :
- api tests return a 404 error for each query so prove fail in debian (centos is working fine)