### PR TITLE
update.py: Filter defs when indexing refs

### DIFF
--- a/t/100-basic.t
+++ b/t/100-basic.t
@@ -88,7 +88,7 @@ run_produces_ok('ident query (existent)',
     [$query_py, qw(v5.4 ident i2c_acpi_notify C)],
     [qr{^Symbol Definitions:}, qr{^Symbol References:},
         { def => qr{drivers/i2c/i2c-core-acpi\.c.+\b402\b.+\bfunction\b} },
-        { ref => qr{drivers/i2c/i2c-core-acpi\.c.+\b402,439} },
+        { ref => qr{drivers/i2c/i2c-core-acpi\.c.+\b439} },
     ],
     MUST_SUCCEED);
 

--- a/t/api_test.py
+++ b/t/api_test.py
@@ -63,8 +63,7 @@ class APITest(testing.TestCase):
             ],
             'references':
                 [
-                    {'path': 'drivers/i2c/i2c-core-of.c', 'line': '22,62,73', 'type': None},
-                    {'path': 'include/linux/i2c.h', 'line': '941,968', 'type': None}
+                    {'path': 'drivers/i2c/i2c-core-of.c', 'line': '62,73', 'type': None}
                 ],
                 'documentations': []
             }

--- a/update.py
+++ b/update.py
@@ -54,6 +54,7 @@ tag_ready = Condition() # Waiting for new tags
 
 new_idxes = [] # (new idxes, Event idxes ready, Event defs ready, Event comps ready, Event vers ready)
 bindings_idxes = [] # DT bindings documentation files
+defs_idxes = {} # Idents definitions stored with (idx*1 000 000 + line) as the key.
 
 tags_done = False # True if all tags have been added to new_idxes
 
@@ -240,6 +241,8 @@ class UpdateDefs(Thread):
                     type = type.decode()
                     line = int(line.decode())
 
+                    defs_idxes[idx*1000000+line] = ident
+
                     if db.defs.exists(ident):
                         obj = db.defs.get(ident)
                     elif lib.isIdent(ident):
@@ -312,6 +315,8 @@ class UpdateRefs(Thread):
                         tok = prefix + tok
 
                         if (db.defs.exists(tok) and
+                            not ( (idx*1000000+line_num) in defs_idxes and
+                                defs_idxes[idx*1000000+line_num] == tok ) and
                             (family != 'M' or tok.startswith(b'CONFIG_'))):
                             # We only index CONFIG_??? in makefiles
                             if tok in idents:

--- a/update.py
+++ b/update.py
@@ -54,7 +54,8 @@ tag_ready = Condition() # Waiting for new tags
 
 new_idxes = [] # (new idxes, Event idxes ready, Event defs ready, Event comps ready, Event vers ready)
 bindings_idxes = [] # DT bindings documentation files
-defs_idxes = {} # Idents definitions stored with (idx*1 000 000 + line) as the key.
+idx_key_mod = 1000000
+defs_idxes = {} # Idents definitions stored with (idx*idx_key_mod + line) as the key.
 
 tags_done = False # True if all tags have been added to new_idxes
 
@@ -241,7 +242,7 @@ class UpdateDefs(Thread):
                     type = type.decode()
                     line = int(line.decode())
 
-                    defs_idxes[idx*1000000+line] = ident
+                    defs_idxes[idx*idx_key_mod + line] = ident
 
                     if db.defs.exists(ident):
                         obj = db.defs.get(ident)
@@ -315,8 +316,8 @@ class UpdateRefs(Thread):
                         tok = prefix + tok
 
                         if (db.defs.exists(tok) and
-                            not ( (idx*1000000+line_num) in defs_idxes and
-                                defs_idxes[idx*1000000+line_num] == tok ) and
+                            not ( (idx*idx_key_mod + line_num) in defs_idxes and
+                                defs_idxes[idx*idx_key_mod + line_num] == tok ) and
                             (family != 'M' or tok.startswith(b'CONFIG_'))):
                             # We only index CONFIG_??? in makefiles
                             if tok in idents:


### PR DESCRIPTION
This resolves issue https://github.com/bootlin/elixir/issues/196

To do that we store each identifier definition in a dictionary where each key is equal to identifier*1 000 000 + line number.

This doesn't seems to slow down update.py so indexing time should remain the same.
However there can be a problem if a file has more than 1 000 000 lines but I think such file doesn't exists so it should be fine.
If this problem occurs, we'll have to multiply the identifier value with an higher power of 10 in the dictionary keys.