### PR TITLE
vertical-align:top to fix line-number offset on some platforms

### DIFF
--- a/http/style.css
+++ b/http/style.css
@@ -691,6 +691,10 @@ h2 {
   min-height: 100%;
 }
 
+.lxrcode pre * {
+  vertical-align: top;
+}
+
 .lxrcode,
 .highlighttable,
 .linenodiv,


### PR DESCRIPTION
In some browsers (Chrome 93 on Chrome OS, for me) at some resolutions and zoom levels, the line numbers and code become offset because their heights are slightly different (see #46 and #210). On some long files, such as `fs/io_uring.c`, this can cause the line numbers to be offset by dozens of lines by the end of the file; since jump-to-line (from the cross-referencer) jumps to the line number, that also becomes messed up. The root cause of this seems to be that text with different `font-weight` (such as links, which are `font-weight: 700`), and possibly italic fonts as well (used in e.g. comments), have a slightly different font baseline, although the font size is the same. Since the default `vertical-align` is `baseline`, this messes up the height of the line-boxes; `vertical-align: top` or `vertical-align: bottom` fixes this. On platforms where the baselines are different, this may cause some lines to look slightly funny; however, in my opinion this is better than line-number breakage.

The "right answer" for this is probably to use CSS grid to ensure proper alignment. That should avoid the need for the baseline jank, but it's a much more intrusive change.

Before:
![image](https://user-images.githubusercontent.com/3767924/136718632-0570890d-0594-435c-8e6a-e22778b16f2c.png)

After:
![image](https://user-images.githubusercontent.com/3767924/136718678-25bfd2ae-cac2-421e-bf0c-ab1cd0ec0ed0.png)

Mild line jank: (see e.g. the slight, ~1px misalignment of bold symbols vs. non-bold operators)
![image](https://user-images.githubusercontent.com/3767924/136718770-e42d9694-50a4-4ce8-86bf-7bbce196b667.png)

