### PR TITLE
Front-end: make the whole width of all entries clickable

### DIFF
--- a/http/style.css
+++ b/http/style.css
@@ -676,6 +676,7 @@ h2 {
 }
 .size {
   opacity: 0.6;
+  min-height: 1.5em; /* line_height + 2 * padding = 1.2em + 2 * 0.15em */
 }
 
 


### PR DESCRIPTION
The file listing contains a column for displaying sizes. Directories do not have sizes, as such this section is empty. When a directory entry is hovered, the full width illuminates but only the name section can be clicked. This pull request fixes this. It also fixes it for "parent directory" entries.

**This has only been tested by live-editing pages from the Bootlin instance in a browser, it should be tested before merging.** I do not have a functional local Elixir setup to make sure the stylesheet wasn't broken.