### PR TITLE
BUGFIX: Don't double quote DT compatible strings

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -56,9 +56,6 @@ class IdentGetter:
         else:
             family = 'C'
 
-        if family == 'B': #DT compatible strings are quoted in the database
-            ident = parse.quote(ident)
-
         symbol_definitions, symbol_references, symbol_doccomments = query('ident', version, ident, family)
         resp.body = json.dumps(
             {

--- a/query.py
+++ b/query.py
@@ -244,6 +244,7 @@ def get_idents_comps(version, ident):
     symbol_dts = []
     symbol_docs = []
 
+    # DT compatible strings are quoted in the database
     ident = parse.quote(ident)
 
     if not dts_comp_support or not db.comps.exists(ident):


### PR DESCRIPTION
BUGFIX: Don't double quote DT compatible strings

Both query.py and api.py call parse.quote(ident) which perform
url encoding twice on the identifier. For instance, when
ident="linux,kvm" the first encoding done in api.py changes the
ident to 'wow%2Cey' but the second encoding done in query.py
changes it to 'wow%252Cey' which is no longer valid.

Remove the call to parse.quote on api.py as only one quoting is
necessary, the one in query.py