### PR TITLE
align size to right

### DIFF
--- a/http/style.css
+++ b/http/style.css
@@ -677,6 +677,7 @@ h2 {
 .size {
   opacity: 0.6;
   min-height: 1.5em; /* line_height + 2 * padding = 1.2em + 2 * 0.15em */
+  text-align: right;
 }
 
 


### PR DESCRIPTION
to make it more readable because
same units are located on the same column:

```
    9 bytes
99999 bytes

instead of

9 bytes
99999 bytes
```
