### PR TITLE
Multi languages support other than C/C++

### DIFF
--- a/data.py
+++ b/data.py
@@ -31,15 +31,22 @@ deflist_macro_regex = re.compile('\dM\d+(\w)')
 ##################################################################################
 
 defTypeR = {
+    'C': 'class',
     'c': 'config',
     'd': 'define',
     'e': 'enum',
     'E': 'enumerator',
     'f': 'function',
+    'g': 'field',
+    'h': 'func',
     'l': 'label',
     'M': 'macro',
     'm': 'member',
+    'N': 'module',
+    'n': 'method',
+    'P': 'package',
     'p': 'prototype',
+    'S': 'subroutine',
     's': 'struct',
     't': 'typedef',
     'u': 'union',

--- a/lib.py
+++ b/lib.py
@@ -196,7 +196,7 @@ def currentProject():
     return os.path.basename(os.path.dirname(getDataDir()))
 
 # List all families supported by Elixir
-families = ['A', 'B', 'C', 'D', 'K', 'M']
+families = ['A', 'B', 'C', 'D', 'E', 'K', 'M']
 
 def validFamily(family):
     return family in families
@@ -206,6 +206,8 @@ def getFileFamily(filename):
 
     if ext.lower() in ['.c', '.cc', '.cpp', '.c++', '.cxx', '.h', '.s'] :
         return 'C' # C file family and ASM
+    elif ext.lower() in ['.go', '.java', 'php', 'pl', '.py', '.rb', '.rs', '.sh'] :
+        return 'E' # Other than C family
     elif ext.lower() in ['.dts', '.dtsi'] :
         return 'D' # Devicetree files
     elif name.lower()[:7] in ['kconfig'] and not ext.lower() in ['.rst']:
@@ -221,6 +223,7 @@ def getFileFamily(filename):
 # 2 chars values with a M are macros families
 compatibility_list = {
     'C' : ['C', 'K'],
+    'E' : ['E'],
     'K' : ['K'],
     'D' : ['D', 'CM'],
     'M' : ['K']

--- a/query.py
+++ b/query.py
@@ -241,6 +241,7 @@ def get_idents_comps(version, ident):
     # Used in DT files
     # Documented in documentation files
     symbol_c = []
+    symbol_others = []
     symbol_dts = []
     symbol_docs = []
 
@@ -261,6 +262,7 @@ def get_idents_comps(version, ident):
     comps_idx, comps_lines, comps_family = next(comps)
     comps_docs_idx, comps_docs_lines, comps_docs_family = next(comps_docs)
     compsCBuf = [] # C/CPP/ASM files
+    compsEBuf = [] # Other than C files
     compsDBuf = [] # DT files
     compsBBuf = [] # DT bindings docs files
 
@@ -274,6 +276,8 @@ def get_idents_comps(version, ident):
         if comps_idx == file_idx:
             if comps_family == 'C':
                 compsCBuf.append((file_path, comps_lines))
+            elif comps_family == 'E':
+                compsEBuf.append((file_path, comps_lines))
             elif comps_family == 'D':
                 compsDBuf.append((file_path, comps_lines))
 
@@ -283,13 +287,16 @@ def get_idents_comps(version, ident):
     for path, cline in sorted(compsCBuf):
         symbol_c.append(SymbolInstance(path, cline, 'compatible'))
 
+    for path, eline in sorted(compsEBuf):
+        symbol_others.append(SymbolInstance(path, eline))
+
     for path, dlines in sorted(compsDBuf):
         symbol_dts.append(SymbolInstance(path, dlines))
 
     for path, blines in sorted(compsBBuf):
         symbol_docs.append(SymbolInstance(path, blines))
 
-    return symbol_c, symbol_dts, symbol_docs
+    return symbol_c, symbol_others, symbol_dts, symbol_docs
 
 def get_idents_defs(version, ident, family):
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -28,6 +28,7 @@
                         <select name="f" title="Restricts search to specific file families">
                             <option value="A" {% if family=="A" %} selected="selected"{% endif %}>All symbols</option>
                             <option value="C" {% if family=="C" %} selected="selected"{% endif %}>C/CPP/ASM</option>
+                            <option value="E" {% if family=="E" %} selected="selected"{% endif %}>non C/CPP/ASM</option>
                             <option value="K" {% if family=="K" %} selected="selected"{% endif %}>Kconfig</option>
                             <option value="D" {% if family=="D" %} selected="selected"{% endif %}>Devicetree</option>
                             <option value="B" {% if family=="B" %} selected="selected"{% endif %}>DT compatible</option>


### PR DESCRIPTION
The files with the following file extensions are also parsed by the 
ctags command with default options for each languages.

  .go .java .php .pl .py .rb .rs .sh