### PR TITLE
Update Debian Dockerfile to Debian Bookworm

### DIFF
--- a/docker/debian/000-default.conf
+++ b/docker/debian/000-default.conf
@@ -1,0 +1,24 @@
+<Directory /usr/local/elixir/http/>
+    Options +ExecCGI
+    AllowOverride None
+    Require all granted
+    SetEnv PYTHONIOENCODING utf-8
+    SetEnv LXR_PROJ_DIR /srv/elixir-data
+</Directory>
+<Directory /usr/local/elixir/api/>
+    SetHandler wsgi-script
+    Require all granted
+    SetEnv PYTHONIOENCODING utf-8
+    SetEnv LXR_PROJ_DIR /srv/elixir-data
+</Directory>
+AddHandler cgi-script .py
+<VirtualHost *:80>
+    ServerName MY_LOCAL_IP
+    DocumentRoot /usr/local/elixir/http
+    WSGIScriptAlias /api /usr/local/elixir/api/api.py
+    AllowEncodedSlashes On
+    RewriteEngine on
+    RewriteRule "^/$" "/linux/latest/source" [R]
+    RewriteRule "^/(?!api|acp).*/(source|ident|search)" "/web.py" [PT]
+    RewriteRule "^/acp" "/autocomplete.py" [PT]
+</VirtualHost>

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:bookworm
 ARG GIT_REPO_URL
 ARG PROJECT
 
@@ -11,14 +11,17 @@ RUN \
 RUN \
     echo "repo url to index: ${GIT_REPO_URL}"
 
+
 RUN \
   apt-get update && \
   apt-get -y install \
     python3 \
     python3-pip \
+    python3-falcon \
     python3-jinja2 \
     python3-bsddb3 \
     python3-pytest \
+    pipx \
     perl \
     git \
     apache2 \
@@ -26,12 +29,6 @@ RUN \
     libjansson4 \
     libyaml-0-2 \
     wget
-
-RUN \
-  pip3 install falcon
-
-RUN \
-  ln -s /usr/bin/pytest-3 /usr/bin/pytest
 
 RUN \
   wget https://bootlin.com/pub/elixir/universal-ctags_0+git20200526-0ubuntu1_amd64.deb
@@ -43,7 +40,7 @@ RUN \
   wget https://bootlin.com/pub/elixir/Pygments-2.6.1.elixir-py3-none-any.whl
 
 RUN \
-  pip3 install Pygments-2.6.1.elixir-py3-none-any.whl
+  pipx install ./Pygments-2.6.1.elixir-py3-none-any.whl
 
 RUN \
   git config --global user.email 'elixir@dummy.com' && \
@@ -53,12 +50,11 @@ RUN \
   git clone https://github.com/bootlin/elixir.git /usr/local/elixir/
 
 RUN \
-  mkdir -p /srv/elixir-data/
-
-RUN \
+  mkdir -p /srv/elixir-data/ && \
   mkdir -p /srv/elixir-data/$PROJECT/repo && \
   mkdir -p /srv/elixir-data/$PROJECT/data && \
-  git clone --bare "${GIT_REPO_URL}" /srv/elixir-data/$PROJECT/repo/
+  git clone --bare "${GIT_REPO_URL}" /srv/elixir-data/$PROJECT/repo/ && \
+  git config --global --add safe.directory /srv/elixir-data/$PROJECT/repo
 
 ENV LXR_REPO_DIR /srv/elixir-data/$PROJECT/repo
 ENV LXR_DATA_DIR /srv/elixir-data/$PROJECT/data
@@ -66,12 +62,14 @@ ENV LXR_DATA_DIR /srv/elixir-data/$PROJECT/data
 RUN \
   cd /usr/local/elixir/ && \
   ./script.sh list-tags && \
-  python3 -u ./update.py
+  python3 -u ./update.py && \
+  chown -R www-data:www-data /srv/elixir-data/$PROJECT/repo
 
 # apache elixir config, see elixir README
 # make apache less stricter about cgitb spam headers
+COPY ./docker/debian/000-default.conf /etc/apache2/sites-available/000-default.conf
+
 RUN \
-  echo PERpcmVjdG9yeSAvdXNyL2xvY2FsL2VsaXhpci9odHRwLz4KICAgIE9wdGlvbnMgK0V4ZWNDR0kKICAgIEFsbG93T3ZlcnJpZGUgTm9uZQogICAgUmVxdWlyZSBhbGwgZ3JhbnRlZAogICAgU2V0RW52IFBZVEhPTklPRU5DT0RJTkcgdXRmLTgKICAgIFNldEVudiBMWFJfUFJPSl9ESVIgL3Nydi9lbGl4aXItZGF0YQo8L0RpcmVjdG9yeT4KPERpcmVjdG9yeSAvdXNyL2xvY2FsL2VsaXhpci9hcGkvPgogICAgU2V0SGFuZGxlciB3c2dpLXNjcmlwdAogICAgUmVxdWlyZSBhbGwgZ3JhbnRlZAogICAgU2V0RW52IFBZVEhPTklPRU5DT0RJTkcgdXRmLTgKICAgIFNldEVudiBMWFJfUFJPSl9ESVIgL3Nydi9lbGl4aXItZGF0YQo8L0RpcmVjdG9yeT4KQWRkSGFuZGxlciBjZ2ktc2NyaXB0IC5weQo8VmlydHVhbEhvc3QgKjo4MD4KICAgIFNlcnZlck5hbWUgTVlfTE9DQUxfSVAKICAgIERvY3VtZW50Um9vdCAvdXNyL2xvY2FsL2VsaXhpci9odHRwCiAgICBXU0dJU2NyaXB0QWxpYXMgL2FwaSAvdXNyL2xvY2FsL2VsaXhpci9hcGkvYXBpLnB5CiAgICBBbGxvd0VuY29kZWRTbGFzaGVzIE9uCiAgICBSZXdyaXRlRW5naW5lIG9uCiAgICBSZXdyaXRlUnVsZSAiXi8kIiAiL2xpbnV4L2xhdGVzdC9zb3VyY2UiIFtSXQogICAgUmV3cml0ZVJ1bGUgIl4vKD8hYXBpfGFjcCkuKi8oc291cmNlfGlkZW50fHNlYXJjaCkiICIvd2ViLnB5IiBbUFRdCiAgICBSZXdyaXRlUnVsZSAiXi9hY3AiICIvYXV0b2NvbXBsZXRlLnB5IiBbUFRdCjwvVmlydHVhbEhvc3Q+Cg== | base64 -d > /etc/apache2/sites-available/000-default.conf && \
   echo -e "\nHttpProtocolOptions Unsafe" >> /etc/apache2/apache.conf && \
   a2enmod cgi rewrite
 


### PR DESCRIPTION
Hello, 

yesterday I tried building Debian image of Elixir. However, the build wouldn't complete due to various errors. In order to fix the Dockerfile, I have done the following changes: 

* Pin base version to debian:bookworm
* Install falcon with apt, install pipx and use pipx to install Pygments - global package installation with pip is not supported anymore
* Update repo permissions and add elixir-data to git safe directories so that git ran from script.sh and cgi stops complaining
* Move apache configuration to an external file for better readability

I also propose (not included in this patch) moving the build args check (lines 5 to 12) to just before git clone of the repo (line 53). 
Currently, if someone builds the image with one project, and then tries to build another image with a different project, Docker builder will redo all commands - that includes cloning Elixir and installing all pip/apt packages. 
If build arg checks were executed after Elixir and all of its dependencies are installed, Docker builder could reuse these layers and building images with different repositories would be faster, since the layers that install Elixir and its dependencies wouldn't be dependent on build args.