### PR TITLE
Fix pygments installation

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -14,13 +14,14 @@ RUN \
 
 RUN \
   apt-get update && \
-  apt-get -y install \
+  apt-get --no-install-recommends -y install \
     python3 \
     python3-pip \
     python3-falcon \
     python3-jinja2 \
     python3-bsddb3 \
     python3-pytest \
+    python3-pygments- \
     pipx \
     perl \
     git \
@@ -40,7 +41,7 @@ RUN \
   wget https://bootlin.com/pub/elixir/Pygments-2.6.1.elixir-py3-none-any.whl
 
 RUN \
-  pipx install ./Pygments-2.6.1.elixir-py3-none-any.whl
+  pip3 install ./Pygments-2.6.1.elixir-py3-none-any.whl --break-system-packages
 
 RUN \
   git config --global user.email 'elixir@dummy.com' && \


### PR DESCRIPTION
Fix pygments installation by explicitly excluding pygments from apt install and force installing pygments distribution using pip.
Choice to use `--break-system-packages` is probably controversial, its a rather hacky solution, but since the Dockerfile is single purpose I think it should be fine. 
I couldn't figure out how to properly configure apache cgi to use virtualenv. Per-user installation does not seem like a good choice in this case.