### PR TITLE
Support for FreeBSD

### DIFF
--- a/projects/freebsd.sh
+++ b/projects/freebsd.sh
@@ -1,0 +1,15 @@
+# FreeBSD
+
+version_dir()
+{
+    grep "^release/[0-9]*\.[0-9]*\.[0-9]*$" |
+    sed -e 's,^release/,v,' |
+    sed -e 's,\.0$,,';
+}
+
+version_rev()
+{
+    grep "^v" |
+    sed -e 's,v[0-9]*\.[0-9]*$,&\.0,' |
+    sed -e 's,^v,release/,';
+}


### PR DESCRIPTION
Add support for indexing the FreeBSD base repository, found at:

https://cgit.freebsd.org/src/

This contains the FreeBSD kernel plus the base system.