### PR TITLE
Remove query.default_query and all related references

### DIFF
--- a/http/autocomplete.py
+++ b/http/autocomplete.py
@@ -31,19 +31,20 @@ query_project = form.getvalue('p')
 
 # Get project dirs
 basedir = os.environ['LXR_PROJ_DIR']
-os.environ['LXR_DATA_DIR'] = basedir + '/' + query_project + '/data'
-os.environ['LXR_REPO_DIR'] = basedir + '/' + query_project + '/repo'
+datadir = basedir + '/' + query_project + '/data'
+repodir = basedir + '/' + query_project + '/repo'
 
 # Import query
 sys.path = [ sys.path[0] + '/..' ] + sys.path
-from query import query
+from query import Query
+q = Query(datadir, repodir)
 
 # Create tmp directory for autocomplete
 tmpdir = '/tmp/autocomplete/' + query_project
 if not(os.path.isdir(tmpdir)):
     os.makedirs(tmpdir, exist_ok=True)
 
-latest = query('latest')
+latest = q.query('latest')
 
 # Define some specific values for some families
 if query_family == 'B':
@@ -65,7 +66,7 @@ if not f.readline()[:-1] == latest:
     f.seek(0)
     f.truncate()
     f.write(latest + "\n")
-    f.write('\n'.join([process(x.decode()) for x in query('keys', name)]))
+    f.write('\n'.join([process(x.decode()) for x in q.query('keys', name)]))
     f.seek(0)
     f.readline() # Skip first line that store the version number
 

--- a/http/filters/dtscompB.py
+++ b/http/filters/dtscompB.py
@@ -5,7 +5,7 @@ dtscompB = []
 def keep_dtscompB(m):
     text = m.group(1)
 
-    if query('dts-comp-exists', parse.quote(text)):
+    if q.query('dts-comp-exists', parse.quote(text)):
         dtscompB.append(text)
         return '__KEEPDTSCOMPB__' + encode_number(len(dtscompB))
     else:

--- a/http/filters/makefiledir.py
+++ b/http/filters/makefiledir.py
@@ -9,7 +9,7 @@ def keep_makefiledir(m):
     if dir_name != '/':
         dir_name += '/'
 
-    if query('exist', tag, dir_name + m.group(1) + '/Makefile'):
+    if q.query('exist', tag, dir_name + m.group(1) + '/Makefile'):
         makefiledir.append(m.group(1))
         return '__KEEPMAKEFILEDIR__' + encode_number(len(makefiledir)) + '/' + m.group(2)
     else:

--- a/http/filters/makefilefile.py
+++ b/http/filters/makefilefile.py
@@ -8,7 +8,7 @@ def keep_makefilefile(m):
     if dir_name != '/':
         dir_name += '/'
 
-    if query('exist', tag, dir_name + m.group(1)):
+    if q.query('exist', tag, dir_name + m.group(1)):
         makefilefile.append(m.group(1))
         return '__KEEPMAKEFILEFILE__' + encode_number(len(makefilefile)) + m.group(2)
     else:

--- a/http/filters/makefilesrctree.py
+++ b/http/filters/makefilesrctree.py
@@ -3,7 +3,7 @@
 makefilesrctree = []
 
 def keep_makefilesrctree(m):
-    if query('exist', tag, '/' +  m.group(1)):
+    if q.query('exist', tag, '/' +  m.group(1)):
         makefilesrctree.append(m.group(1))
         return '__KEEPMAKEFILESRCTREE__' + encode_number(len(makefilesrctree)) + m.group(2)
     else:

--- a/http/web.py
+++ b/http/web.py
@@ -131,12 +131,13 @@ for (dirpath, dirnames, filenames) in os.walk(basedir):
     break
 projects.sort()
 
-from query import query
+from query import Query
 
-dts_comp_support = query('dts-comp')
+q = Query(datadir, repodir)
+dts_comp_support = q.query('dts-comp')
 
 if version_decoded == 'latest':
-    tag = query('latest')
+    tag = q.query('latest')
 else:
     tag = version_decoded
 
@@ -154,7 +155,7 @@ data = {
     'breadcrumb': '<a class="project" href="'+version+'/source">/</a>'
 }
 
-versions = query('versions')
+versions = q.query('versions')
 
 v = ''
 b = 1
@@ -207,12 +208,12 @@ if mode == 'source':
 
     lines = ['null - - -']
 
-    type = query('type', tag, path)
+    type = q.query('type', tag, path)
     if len(type) > 0:
         if type == 'tree':
-            lines += query('dir', tag, path)
+            lines += q.query('dir', tag, path)
         elif type == 'blob':
-            code = query('file', tag, path)
+            code = q.query('file', tag, path)
     else:
         print('<div class="lxrerror"><h2>This file does not exist.</h2></div>')
         status = 404
@@ -240,7 +241,7 @@ if mode == 'source':
                     # 120000 permission means it's a symlink
                     # So we need to handle that correctly
                     dir_name = os.path.dirname(path)
-                    rel_path = query('file', tag, path2)
+                    rel_path = q.query('file', tag, path2)
 
                     if dir_name != '/':
                         dir_name += '/'
@@ -271,7 +272,7 @@ if mode == 'source':
         fdir, fname = os.path.split(path)
         filename, extension = os.path.splitext(fname)
         extension = extension[1:].lower()
-        family = query('family', fname)
+        family = q.query('family', fname)
 
         # Source common filter definitions
         os.chdir('filters')
@@ -331,7 +332,7 @@ if mode == 'source':
 elif mode == 'ident':
     data['title'] = ident+' identifier - '+title_suffix
 
-    symbol_definitions, symbol_references, symbol_doccomments = query('ident', tag, ident, family)
+    symbol_definitions, symbol_references, symbol_doccomments = q.query('ident', tag, ident, family)
 
     print('<div class="lxrident">')
     if len(symbol_definitions) or len(symbol_references):

--- a/utils/speedtest.py
+++ b/utils/speedtest.py
@@ -75,24 +75,24 @@ def init_query(project):
         return None;
 
     basedir = os.environ['LXR_PROJ_DIR']
-    os.environ['LXR_DATA_DIR']= basedir + '/' + project + '/data'
-    os.environ['LXR_REPO_DIR'] = basedir + '/' + project + '/repo'
+    datadir = basedir + '/' + project + '/data'
+    repodir = basedir + '/' + project + '/repo'
 
-    import query
-    return query.query
+    from query import Query
+    return Query(datadir, repodir)
 
 
 def get_ident(ident, version):
     if version == 'latest':
-            version = query('latest')
+            version = query.query('latest')
 
-    return query('ident', version, ident[0], ident[1])
+    return query.query('ident', version, ident[0], ident[1])
 
 def get_file(path, version):
     if version == 'latest':
-            version = query('latest')
+            version = query.query('latest')
 
-    return query('file', version, path)
+    return query.query('file', version, path)
 
 
 #Read arguments


### PR DESCRIPTION
* Remove query.default_query and all related references
* Pass process env vars to script.sh when ran from Query

To test this, I have:
* Made sure that utils/speedtest.py works
* Ran query.py file and query.py ident 
* Made sure that each filter that was modified ran without errors at least once
* Ran prove (the same tests that failed before my commits still fail, but that's a problem for another PR) 
* Made sure that the server works when LXR_DATA_DIR and LXR_REPO_DIR env vars are not globally set 

This patch is already deployed on https://elixir.ksi.ii.uj.edu.pl/linux/latest/source. This time the the global LXR_* env vars were removed from the container.