### PR TITLE
check $lineno valid

### DIFF
--- a/find-file-doc-comments.pl
+++ b/find-file-doc-comments.pl
@@ -131,7 +131,7 @@ sub main {
 
         # Is it actually a header for this function?
         say "  Checking line $lineno for header" if $VERBOSE;
-        next unless $source_lines[$lineno] =~ $this_doc_comment_header;
+        next unless $lineno > 0 && $source_lines[$lineno] =~ $this_doc_comment_header;
 
         # We have found a header.  Confirm it's a doc comment.
         --$lineno;


### PR DESCRIPTION
I faced with the following error when processing linux sources as described in a ReadMe doc:
```
While processing /tmp/tmp.qAxBB9H4WR: Use of uninitialized value in pattern match (m//) at /mnt/work/opensource/elixir/find-file-doc-comments.pl
 line 134.
```

Please, find `tmp.qAxBB9H4WR` attached.
[tmp.qAxBB9H4WR.txt](https://github.com/bootlin/elixir/files/14392945/tmp.qAxBB9H4WR.txt)
