### PR TITLE
docker: Fix debian/Dockerfile filepath and README doc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -357,12 +357,14 @@ where all repositories are found.
 
 = Building Docker images
 
-Docker files are provided in the `docker/` directory. To generate your own
-Docker image for indexing the sources of a project (for example for the Musl
-project which is much faster to index than Linux), download the `Dockerfile`
-file for your target distribution and run:
+Docker files are provided in the `docker/` directory. To generate a Docker image
+for indexing the sources of a project, first fetch the Elixir repository. Then
+pick the project you want to index (Musl is nice test data being not too slow
+to index) and your target distribution (`debian` and `centos` available), and
+run:
 
- $ docker build -t elixir --build-arg GIT_REPO_URL=git://git.musl-libc.org/musl --build-arg PROJECT=musl .
+ $ docker build -t elixir-debian --build-arg GIT_REPO_URL=git://git.musl-libc.org/musl --build-arg PROJECT=musl ./docker/debian/
+ $ docker build -t elixir-centos --build-arg GIT_REPO_URL=git://git.musl-libc.org/musl --build-arg PROJECT=musl ./docker/centos/
 
 Then you can use your new container as follows (you get the container id from the output of `docker build`):
 

--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -68,7 +68,7 @@ RUN \
 
 # apache elixir config, see elixir README
 # make apache less stricter about cgitb spam headers
-COPY ./docker/debian/000-default.conf /etc/apache2/sites-available/000-default.conf
+COPY ./000-default.conf /etc/apache2/sites-available/000-default.conf
 
 RUN \
   echo -e "\nHttpProtocolOptions Unsafe" >> /etc/apache2/apache.conf && \


### PR DESCRIPTION
I won't duplicate commit message here. It contains diff explanations.

**Warning:** it might break scripts generating docker images. `cwd` for Debian Dockerfile must be `docker/debian/` now.

Open question: is `docker/centos/Dockerfile` still up-to-date? I don't see the reason for maintaining two alternatives, especially as containers are supposed to isolate services. It duplicates testing on Dockerfile updates. See 4bea126 and 0512186 for commits that improve Debian Dockerfile but don't touch centos Docker.

@fstachura @michaelopdenacker 