### PR TITLE
Make dtscompcode filter quit early for some files

### DIFF
--- a/http/filters/dtscompcode.py
+++ b/http/filters/dtscompcode.py
@@ -16,6 +16,12 @@ class DtsCompCodeFilter(Filter):
             extension_matches(ctx.filepath, {'c', 'cc', 'cpp', 'c++', 'cxx', 'h', 's'})
 
     def transform_raw_code(self, ctx, code: str) -> str:
+        # quit early if source file does not contain any strings that could be an assignment to a 'compatible' property
+        # this is much faster than the match-and-replace regex, especially for big files
+        compatible_search = re.search('\.(\033\[31m)?compatible(\033\[0m)?\s*=', code, flags=re.MULTILINE)
+        if compatible_search is None:
+            return code
+
         def keep_dtscompC(m):
             self.dtscompC.append(m.group(4))
             return f'{ m.group(1) }"__KEEPDTSCOMPC__{ encode_number(len(self.dtscompC)) }"'


### PR DESCRIPTION
files that don't contain assignments to a 'compatible' property