### PR TITLE
Increase tablet mode min width

### DIFF
--- a/http/style.css
+++ b/http/style.css
@@ -460,7 +460,7 @@ h2 {
   max-height: 50vh;
   max-width: 75vw;
 
-  @media only screen and (max-width: 769px) {
+  @media only screen and (max-width: 1000px) {
     min-width: 100vw;
   }
 }
@@ -1070,7 +1070,7 @@ main {
 }
 
 /* desktop */
-@media screen and (min-width: 769px) {
+@media screen and (min-width: 1000px) {
   .open-menu,
   .close-menu {
     display: none;
@@ -1149,7 +1149,7 @@ main {
   }
 
   /* desktop */
-  @media screen and (min-width: 769px) {
+  @media screen and (min-width: 1000px) {
     .js .linenos {
       left: 235px;
     }

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -10,7 +10,7 @@
         </title>
         <meta name="description" content="Elixir Cross Referencer - Explore source code in your browser - Particularly useful for the Linux kernel and other low-level projects in C/C++ (bootloaders, C libraries...)">
         <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1" />
-        <link rel="stylesheet" href="/style.css?v=5">
+        <link rel="stylesheet" href="/style.css?v=6">
         <link rel="stylesheet" href="/banner.css">
         <link rel="stylesheet" href="/autocomplete.css">
         <script>document.documentElement.className = 'js'</script>


### PR DESCRIPTION
IMO current tablet mode screen width breakpoint is not optimal. The sidebar becomes visible when a device is wider than 768 pixels. 
See for example: https://elixir.bootlin.com/musl/v1.2.5/source/src/select/select.c#L10 (with [responsive design mode](https://firefox-source-docs.mozilla.org/devtools-user/responsive_design_mode/) enabled) 
When a device is 768 pixels wide, ~80 columns of code are visible (until the end of the `restrict` keyword before `efds`). When a device is 769 pixels wide, the sidebar show up and leaves around ~56 columns visible (`restrict` before `wfds`). The number of columns becomes 80 again when device width reaches 1000 pixels. So users of devices with screen width between 769-1000 see only <80 columns at a time. Not very ergonomic, especially since smartphones are very narrow. So vertical mode is also unusable for most users, as they probably see <40 columns.

~1100px should be ~90 columns. 

Note that CSS pixels are not real pixels: http://inamidst.com/stuff/notes/csspx
So for example, the screen resolution of my phone is 2400x1080, but in reality, this amounts to <1000 CSS pixels. But this could also mean, that for some densities this breakpoint still won't be optimal. All devices currently available in responsive design mode on Firefox are less than 1000 CSS pixels wide.