### PR TITLE
Add cache for Query.query('exists')

### DIFF
--- a/query.py
+++ b/query.py
@@ -49,6 +49,7 @@ class Query:
         self.data_dir = data_dir
         self.dts_comp_support = int(self.script('dts-comp'))
         self.db = data.DB(data_dir, readonly=True, dtscomp=self.dts_comp_support)
+        self.file_cache = {}
 
     def script(self, *args):
         return script(*args, env=self.getEnv())
@@ -124,22 +125,22 @@ class Query:
             return decode(self.script('get-type', version, path)).strip()
 
         elif cmd == 'exist':
-
-            # Returns True if the requested file exists, otherwise returns False
-
             version = args[0]
             path = args[1]
 
-            dirname, filename = os.path.split(path)
+            if version not in self.file_cache:
+                version_cache = set()
+                last_dir = None
+                for _, path in self.db.vers.get(version).iter():
+                    dirname, filename = os.path.split(path)
+                    if dirname != last_dir:
+                        last_dir = dirname
+                        version_cache.add(dirname)
+                    version_cache.add(path)
 
-            entries = decode(self.script('get-dir', version, dirname)).split("\n")[:-1]
-            for entry in entries:
-                fname = entry.split(" ")[1]
+                self.file_cache[version] = version_cache
 
-                if fname == filename:
-                    return True
-
-            return False
+            return path.strip('/') in self.file_cache[version]
 
         elif cmd == 'dir':
 


### PR DESCRIPTION
This PR adds a simple cache for 'exists' query. Currently, 'exists' calls `git ls-tree` and parses the results to check if a file exists. A single call takes around 20-30 ms. Some Makefile filters use 'exists' to check if a file referred from a Makefile exists. Large Makefiles can cause a filter to make hundreds of these calls, causing filter processing to take seconds. 

Examples:
* https://github.com/bootlin/elixir/blob/master/http/filters/makefiledir.py#L24
*  https://github.com/bootlin/elixir/blob/master/http/filters/makefilefile.py#L24
* https://github.com/bootlin/elixir/blob/master/http/filters/makefilesrctree.py#L18

This patch makes Makefile processing much faster for large files, although it introduces ~200-300ms of penalty on the first 'exist' call. Subsequent calls are basically free (<0.01ms). 

Note that the cache is never explicitly freed - currently a new Query object is created for each request, so this shouldn't be an issue. In the future it would be a good idea to share Query objects between requests (that arrive to the same WSGI process). This will require some changes related to multithreading, hence is out of scope. update.py does not seem to use Query at all, so it shouldn't be affected by this change. 