### PR TITLE
Add links to ranges of lines

### DIFF
--- a/elixir/web.py
+++ b/elixir/web.py
@@ -290,7 +290,14 @@ def format_code(filename, code):
         lexer = pygments.lexers.get_lexer_by_name('text')
 
     lexer.stripnl = False
-    formatter = pygments.formatters.HtmlFormatter(linenos=True, anchorlinenos=True)
+    formatter = pygments.formatters.HtmlFormatter(
+        # Adds line numbers column to output
+        linenos=True,
+        # Wraps line numbers in link (a) tags
+        anchorlinenos=True,
+        # Wraps each line in a span tag with id='codeline-{line_number}'
+        linespans='codeline'
+    )
     return pygments.highlight(code, lexer, formatter)
 
 # Generate formatted HTML of a file, apply filters (for ex. to add identifier links)

--- a/static/script.js
+++ b/static/script.js
@@ -114,10 +114,127 @@ window.onhashchange = offsetAnchor
 // it can provide the offset in that case too.
 window.requestAnimationFrame(offsetAnchor)
 
+// Parses URL hash (anchor) in format La-Lb where a and b are line numbers,
+// highlights line numbers, scrolls to first line number in range
+function handleLineRange(hashStr) {
+  const hash = hashStr.substring(1).split("-");
+  if (hash.length != 2) {
+    return;
+  }
+
+  const firstLineElement = document.getElementById(hash[0]);
+  const lastLineElement = document.getElementById(hash[1]);
+  if (firstLineElement === undefined || lastLineElement === undefined) {
+    return;
+  }
+
+  highlightFromTo(firstLineElement, lastLineElement);
+  firstLineElement.scrollIntoView();
+}
+
+// Highlights line number elements from firstLineElement to lastLineElement
+function highlightFromTo(firstLineElement, lastLineElement) {
+  let line = firstLineElement.parentNode;
+  const afterLastLineElement = lastLineElement.parentNode.nextElementSibling;
+  while (line !== null && line != afterLastLineElement) {
+    line.firstChild.classList.add("line-highlight");
+    line = line.nextElementSibling;
+  }
+  return true;
+}
+
+// Sets up listeners element that contains line numbers to handle
+// shift-clicks for range highlighting
+function setupLineRangeHandlers() {
+  // Check if page contains the element with line numbers
+  // If not, then likely script is not executed in context of the source page
+  const linenodiv = document.querySelector(".linenodiv");
+  if (linenodiv === null) {
+    return;
+  }
+
+  let rangeStart, rangeEnd;
+  linenodiv.addEventListener("click", ev => {
+    if (ev.ctrlKey || ev.metaKey) {
+      return;
+    }
+    ev.preventDefault();
+
+    // Handler is set on the element that contains all line numbers, check if the
+    // event is directed at an actual line number element
+    const el = ev.target;
+    if (typeof(el.id) !== "string" || el.id[0] !== "L" || el.tagName !== "A") {
+      return;
+    }
+
+    // Remove range highlight
+    const highlightElements = Array.from(document.getElementsByClassName("line-highlight"));
+    for (let el of highlightElements) {
+      el.classList.remove("line-highlight");
+    }
+
+    if (rangeStart === undefined || !ev.shiftKey) {
+      rangeStart = el;
+      rangeStart.classList.add("line-highlight");
+      rangeEnd = undefined;
+      window.location.hash = rangeStart.id;
+    } else if(ev.shiftKey) {
+      if (rangeEnd === undefined) {
+        rangeEnd = el;
+        highlightFromTo(rangeStart, rangeEnd);
+        window.location.hash = `${rangeStart.id}-${rangeEnd.id}`;
+      } else {
+        let rangeStartNumber = parseInt(rangeStart.id.substring(1));
+        let rangeEndNumber = parseInt(rangeEnd.id.substring(1));
+        const elNumber = parseInt(el.id.substring(1));
+        console.assert(!isNaN(rangeStartNumber) && !isNaN(rangeEndNumber) && !isNaN(elNumber),
+          "Elements to highlight have invalid numbers in ids");
+
+        // Swap range elements if rangeStartNumber < rangeEndNumber
+        if (rangeStartNumber > rangeEndNumber) {
+          const rangeTmp = rangeStart;
+          rangeStart = rangeEnd;
+          rangeEnd = rangeTmp;
+
+          const numberTmp = rangeStartNumber;
+          rangeStartNumber = rangeEndNumber;
+          rangeEndNumber = numberTmp;
+        }
+
+        if (elNumber < rangeStartNumber) {
+          // Expand if element above range
+          rangeStart = el;
+        } else if (elNumber > rangeEndNumber) {
+          // Expand if element below range
+          rangeEnd = el;
+        } else {
+          // Shrink moving the edge that's closest to the selection.
+          // Move end if center was selected.
+          const distanceFromStart = Math.abs(rangeStartNumber-elNumber);
+          const distanceFromEnd = Math.abs(rangeEndNumber-elNumber);
+          if (distanceFromStart < distanceFromEnd) {
+            rangeStart = el;
+          } else if (distanceFromStart > distanceFromEnd) {
+            rangeEnd = el;
+          } else {
+            rangeEnd = el;
+          }
+        }
+
+        highlightFromTo(rangeStart, rangeEnd);
+        window.location.hash = `${rangeStart.id}-${rangeEnd.id}`;
+      }
+    }
+  });
+}
+
 // recalculate scroll when page is fully loaded
 // in case of slow rendering very long pages.
 window.onload = function () {
   window.requestAnimationFrame(offsetAnchor)
+
+  handleLineRange(window.location.hash);
+  setupLineRangeHandlers();
 
   // fix incorrectly issued 301 redirect
   // https://developer.mozilla.org/en-US/docs/Web/API/Request/cache

--- a/static/script.js
+++ b/static/script.js
@@ -115,7 +115,8 @@ window.onhashchange = offsetAnchor
 window.requestAnimationFrame(offsetAnchor)
 
 // Parses URL hash (anchor) in format La-Lb where a and b are line numbers,
-// highlights line numbers, scrolls to first line number in range
+// highlights range between (and including) line numbers, scrolls to the
+// first line number in range.
 function handleLineRange(hashStr) {
   const hash = hashStr.substring(1).split("-");
   if (hash.length != 2) {
@@ -134,16 +135,30 @@ function handleLineRange(hashStr) {
 
 // Highlights line number elements from firstLineElement to lastLineElement
 function highlightFromTo(firstLineElement, lastLineElement) {
-  let line = firstLineElement.parentNode;
-  const afterLastLineElement = lastLineElement.parentNode.nextElementSibling;
-  while (line !== null && line != afterLastLineElement) {
-    line.firstChild.classList.add("line-highlight");
-    line = line.nextElementSibling;
-  }
-  return true;
+  let firstLine = parseInt(firstLineElement.id.substring(1));
+  let lastLine = parseInt(lastLineElement.id.substring(1));
+  console.assert(!isNaN(firstLine) && !isNaN(lastLine),
+    "Elements to highlight have invalid numbers in ids");
+
+  console.assert(firstLine < lastLine, "first highlight line is after last highlight line");
+
+  const firstCodeLine = document.getElementById(`codeline-${ firstLine }`);
+  const lastCodeLine = document.getElementById(`codeline-${ lastLine }`);
+
+  addClassToRangeOfElements(firstLineElement.parentNode, lastLineElement.parentNode, "line-highlight");
+  addClassToRangeOfElements(firstCodeLine, lastCodeLine, "line-highlight");
 }
 
-// Sets up listeners element that contains line numbers to handle
+function addClassToRangeOfElements(first, last, class_name) {
+  let element = first;
+  const elementAfterLast = last !== null ? last.nextElementSibling : null;
+  while (element !== null && element != elementAfterLast) {
+    element.classList.add(class_name);
+    element = element.nextElementSibling;
+  }
+}
+
+// Sets up listeners on element that contains line numbers to handle
 // shift-clicks for range highlighting
 function setupLineRangeHandlers() {
   // Check if page contains the element with line numbers

--- a/static/style.css
+++ b/static/style.css
@@ -767,6 +767,17 @@ h2 {
   height: 100%;
 }
 
+span[id^='codeline-'] {
+  display: block;
+  padding-left: 1em;
+}
+
+span[id^='codeline-'].line-highlight {
+  width: 100%;
+  height: 100%;
+  background: #f8edc3;
+}
+
 .linenodiv {
   background: #e9e9e9;
 }
@@ -783,6 +794,10 @@ h2 {
   background: #ccc;
 }
 .linenodiv pre a.line-highlight,
+.linenodiv pre span {
+  display: inline-block;
+}
+.linenodiv pre span.line-highlight > a,
 .linenodiv pre a:target {
   color: #444;
 }
@@ -801,9 +816,6 @@ h2 {
   outline: 1px;
   outline-style: dotted;
   outline-offset: -1px;
-}
-.highlight pre {
-  padding-left: 1em;
 }
 
 .highlight a {

--- a/static/style.css
+++ b/static/style.css
@@ -776,9 +776,17 @@ h2 {
   display: inline-block;
   padding: 0 1em;
   width: 100%;
+  scroll-margin: 15vh;
+  scroll-margin-top: 15vh;
 }
+.line-highlight {
+  background: #ccc;
+}
+.linenodiv pre a.line-highlight,
 .linenodiv pre a:target {
   color: #444;
+}
+.linenodiv pre a:target {
   background: #ccc;
   pointer-events: none;
 }


### PR DESCRIPTION
Click line anchor and another line anchor holding shift to make a link to a range of lines. Clicking on any line number clears the range. I decided to make some additional changes to allow highlighting whole lines of code in a separate commit.

Closes #238

![image](https://github.com/user-attachments/assets/09badde3-b735-4bc5-a129-3e3b7d1b7c3c)

Note: this doesn't work without javascript at all. Since URL hashes are not included in the URL passed over HTTP, line highlights can be rendered on the backend only if a different way of passing information about them was used (for example, query parameters). But also, the only non-javascript way of scrolling to an element that I know of is using a hash parameter...