### PR TITLE
Migrate from bsddb3 to berkeleydb

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,9 +11,8 @@ RUN \
 
 WORKDIR /build/
 
-# TODO switch to berkeleydb
 # NOTE wheel version MUST be sycnhronized with requirements.txt
-RUN pip wheel bsddb3==6.2.9
+RUN pip wheel berkeleydb==18.1.10
 
 FROM debian:bookworm
 
@@ -37,11 +36,11 @@ COPY . /usr/local/elixir/
 
 WORKDIR /usr/local/elixir/
 
-COPY --from=build /build/bsddb3-6.2.9-*.whl /tmp/build/
+COPY --from=build /build/berkeleydb-*.whl /tmp/build/
 
 RUN python3 -m venv venv && \
     . ./venv/bin/activate && \
-    pip install /tmp/build/bsddb3-6.2.9-*.whl && \
+    pip install /tmp/build/berkeleydb-*.whl && \
     pip install -r requirements.txt
 
 RUN mkdir -p /srv/elixir-data/

--- a/elixir/autocomplete.py
+++ b/elixir/autocomplete.py
@@ -22,7 +22,7 @@ import sys
 import os
 import json
 from urllib import parse
-from bsddb3.db import DB_SET_RANGE
+from berkeleydb.db import DB_SET_RANGE
 import falcon
 
 from .lib import autoBytes, validFamily

--- a/elixir/data.py
+++ b/elixir/data.py
@@ -18,7 +18,7 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with Elixir.  If not, see <http://www.gnu.org/licenses/>.
 
-import bsddb3
+import berkeleydb
 import re
 from .lib import autoBytes
 import os
@@ -147,14 +147,14 @@ class RefList:
 class BsdDB:
     def __init__(self, filename, readonly, contentType):
         self.filename = filename
-        self.db = bsddb3.db.DB()
+        self.db = berkeleydb.db.DB()
         if readonly:
-            self.db.open(filename, flags=bsddb3.db.DB_RDONLY)
+            self.db.open(filename, flags=berkeleydb.db.DB_RDONLY)
         else:
             self.db.open(filename,
-                flags=bsddb3.db.DB_CREATE,
+                flags=berkeleydb.db.DB_CREATE,
                 mode=0o644,
-                dbtype=bsddb3.db.DB_BTREE)
+                dbtype=berkeleydb.db.DB_BTREE)
         self.ctype = contentType
 
     def exists(self, key):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Pygments==2.11.2
 Falcon @ git+https://github.com/falconry/falcon.git@cbca63dc7739720eab856f48b32f9e782438be7a
 pytest==7.2.1
 
-# NOTE binary wheels of bsddb3 are not distributed - on Debian this may
+# NOTE binary wheels of berkeleydb are not distributed - on Debian this may
 # require installing build-essentials, python3-dev and libdb-dev
 # NOTE keep in sync with wheel version in the Dockerfile
-bsddb3==6.2.9
+berkeleydb==18.1.10


### PR DESCRIPTION
I ran an update job on an two copies of an existing Linux database, one with bsddb, and the other with berkeleydb. Dumps of resulting databases were identical. 

I still would do a backup of the databases before merging this, just in case. 

Closes #290 