### PR TITLE
web: Meta descriptions improvements

### DIFF
--- a/templates/ident.html
+++ b/templates/ident.html
@@ -1,12 +1,23 @@
 {% extends "layout.html" %}
 
 {% block title %}
-    {{ searched_ident|e }} identifier - {{ current_project|capitalize }} source code {{ current_tag }} - Bootlin
+    {{ searched_ident|e }} identifier - {{ current_project|capitalize }} source code {{ current_tag }} - Bootlin Elixir Cross Referencer
 {% endblock %}
 
 {% block description -%}
-    Elixir Cross Referencer - identifier references search for {{ current_project|capitalize }} (version {{ current_tag }}). Searched identifier: {{ searched_ident|e }}
-{%- endblock %}
+    Elixir Cross Referencer - {{ searched_ident|e }} identifier references search for {{ current_project|capitalize }} {{ current_tag }}.
+    {%- for section in symbol_sections -%}
+        {%- if 'symbols' in section -%}
+            {%- for type, symbols in (section['symbols'].items()) -%}
+                {%- if (symbols|length) == 1 %}
+                    {{ section['title'] }} {{- ' as a '+type if type != '_unknown' else '' }} in {{ symbols[0].path }}.
+                {%- else %}
+                    {{ section['title'] }} in {{ symbols|length }} files {{- ' as a '+type if type != '_unknown' else '' -}}: {{ symbols[0].path }}...
+                {%- endif %}
+            {%- endfor -%}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endblock -%}
 
 {% block main %}
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -6,7 +6,7 @@
         <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
         <title>
         {% block title %}
-            Elixir - Bootlin
+            Bootlin - Elixir Cross Referencer
         {% endblock %}
         </title>
         <meta name="description"

--- a/templates/source.html
+++ b/templates/source.html
@@ -1,11 +1,11 @@
 {% extends "layout.html" %}
 
 {% block title %}
-    {{ title_path }} {{ current_project|capitalize }} source code {{ current_tag }} - Bootlin
+    {{ title_path }} {{ current_project|capitalize }} source code {{ current_tag }} - Bootlin Elixir Cross Referencer
 {% endblock %}
 
 {% block description -%}
-    Elixir Cross Referencer - source file of {{ current_project|capitalize }} (version {{ current_tag }}). Browsed file: {{ '/' if path|length == 0 else path }}
+    Elixir Cross Referencer - source code of {{ current_project|capitalize }} {{ current_tag -}} {{- '' if path|length <= 1 else ': ' + path[1:] }}
 {%- endblock %}
 
 {% block main %}

--- a/templates/tree.html
+++ b/templates/tree.html
@@ -1,14 +1,14 @@
 {% extends "layout.html" %}
 
 {% block title %}
-    {{ title_path }} {{ current_project|capitalize }} source code ({{ current_tag }}) - Bootlin
+    {{ title_path }} {{ current_project|capitalize }} source code ({{ current_tag }}) - Bootlin Elixir Cross Referencer
 {% endblock %}
 
 {% block description -%}
     {%- if path == '' -%}
         Elixir Cross Referencer - explore {{ current_project|capitalize }} {{ current_tag }} source code in your browser.
     {%- else -%}
-        Elixir Cross Referencer - source tree of {{ current_project|capitalize }} (version {{ current_tag }}). Browsed path: {{ '/' if path|length == 0 else path }}
+        Elixir Cross Referencer - source tree of {{ current_project|capitalize }} {{ current_tag -}} {{- '' if path|length <= 1 else ': ' + path[1:] }}
     {%- endif -%}
 {%- endblock -%}
 


### PR DESCRIPTION
* Make source tree descriptions shorter
* Make default title more descriptive
* Add a short summary of results to ident search description

Addresses some of my problems with how new descriptions are rendered in Google results:
![image](https://github.com/user-attachments/assets/50be1a3f-381d-4a59-ad00-d6c68a15dec4)
I think the version keyword is redundant. 

Previous description for /ident generated by Google contained parts of the actual ident search results, and I think that was useful. Here is a screen of results from some older instance hosted by someone else. 

![image](https://github.com/user-attachments/assets/fe05827c-55a7-48d5-bc6a-00046d4bdc00)
