### PR TITLE
web: Explicitly close Query after finishing request

### DIFF
--- a/elixir/autocomplete.py
+++ b/elixir/autocomplete.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 #  This file is part of Elixir, a source code cross-referencer.
 #
 #  Copyright (C) 2017--2020 Maxime Chretien <maxime.chretien@bootlin.com>
@@ -84,4 +83,6 @@ class AutocompleteResource:
         resp.status = falcon.HTTP_200
         resp.content_type = falcon.MEDIA_JSON
         resp.media = response
+
+        query.close()
 

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -98,6 +98,8 @@ class SourceResource:
         resp.content_type = falcon.MEDIA_HTML
         resp.status, resp.text = generate_source_page(req.context, query, project, version, path)
 
+        query.close()
+
 # Handles source URLs without a path, ex. '/u-boot/v2023.10/source'.
 # Note lack of trailing slash
 class SourceWithoutPathResource(SourceResource):
@@ -154,6 +156,8 @@ class IdentResource(IdentPostRedirectResource):
 
         resp.content_type = falcon.MEDIA_HTML
         resp.status, resp.text = generate_ident_page(req.context, query, project, version, family, ident)
+
+        query.close()
 
 # Handles ident URLs when family is not specified in the URL
 # Also handles POST requests for ident URLs without family - IdentPostRedirectResource is


### PR DESCRIPTION
API closes Query and isn't known to leak memory.
BsdDB seems to have automatic destructors, but maybe there are
some caveats.
The documentation does not say that objects have to be closed
explicitly... But it probably won't hurt. And this is the only
hint I found when trying to debug the leak so far.

https://hg.jcea.es/pybsddb/file/6.2.9/Modules/_bsddb.c#l8943
https://pybsddb.sourceforge.net/bsddb3.html