### PR TITLE
Make versions tree shorter

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -433,7 +433,7 @@ h2 {
   list-style: none;
   margin: 0;
 }
-.sidebar nav li.active a {
+.sidebar nav a.active {
   color: #eee;
   color: #6d7dd2;
   font-weight: 700;
@@ -509,9 +509,9 @@ h2 {
           flex: 1;
 }
 
-.js .sidebar li li::before {
+.js .sidebar li li::before,
+.js .sidebar .ver-links a::before {
   color: #444;
-  font-family: 'Ubuntu Mono', monospace;
   font-size: 1.29em;
   line-height: 1;
 }
@@ -521,16 +521,16 @@ h2 {
 .js .sidebar li li:last-of-type::before {
   content: '└╴';
 }
-.js .sidebar li li li::before {
+.js .sidebar .ver-links a::before {
   content: '│\00a0├╴';
 }
-.js .sidebar li li li:last-of-type::before {
+.js .sidebar .ver-links a:last-of-type::before {
   content: '│\00a0└╴';
 }
-.js .sidebar li li:last-of-type li::before {
+.js .sidebar li li:last-of-type .ver-links a::before {
   content: '\00a0\00a0├╴';
 }
-.js .sidebar li li:last-of-type li:last-of-type::before {
+.js .sidebar li li:last-of-type .ver-links a:last-of-type::before {
   content: '\00a0\00a0└╴';
 }
 
@@ -540,7 +540,8 @@ h2 {
 .js .sidebar .versions {
   margin-left: -0.4em;
 }
-.js .sidebar li {
+.js .sidebar li,
+.js .sidebar .ver-links a {
   display: block;
   line-height: 1.5;
 }
@@ -571,17 +572,14 @@ h2 {
   content: '▾';
 }
 
-.js .sidebar .li-link {
+.js .sidebar .ver-link,
+.js .sidebar .ver-links a {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
 }
-.js .sidebar .li-link::before {
-  -webkit-box-flex: 0;
-      -ms-flex: 0;
-          flex: 0;
-}
-.js .sidebar .li-link a {
+.js .sidebar .ver-link,
+.js .sidebar .ver-links a {
   word-break: break-word;
   -webkit-box-flex: 1;
       -ms-flex: 1;
@@ -589,11 +587,13 @@ h2 {
 }
 
 /* tag menu tree closed */
+.js .sidebar nav ul .ver-links,
 .js .sidebar nav ul ul {
   display: none;
 }
 /* tag menu tree open */
-.js .sidebar li span.active + ul {
+.js .sidebar li span.active + ul,
+.js .sidebar li span.active + .ver-links {
   display: block;
 }
 
@@ -607,6 +607,9 @@ h2 {
 }
 .no-js .versions {
   margin-top: 1em;
+}
+.no-js .versions .ver-links a {
+  display: block;
 }
 
 .no-js .sub-header {

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -20,31 +20,29 @@
         <h3 class="screenreader">Versions</h3>
         <ul class="versions">
             {% set current_major, current_minor, current_version = current_version_path %}
+
             {%- for major, major_versions in (versions|default({})).items() -%}
             <li> {{- "" -}}
-                <span class="{{ 'active' if current_major == major else '' }}">{{ major }}</span> {{- "" -}}
+                <span {{ 'class=\"active\"' if current_major == major else '' }}>{{ major }}</span> {{- "" -}}
                 <ul>
                 {%- for minor, minor_versions in major_versions.items() -%}
                     {%- if minor == minor_versions[0] and minor_versions|length == 1 -%}
-                        <li class="li-link"> {{- "" -}}
-                            <a href="{{ minor_versions[0].url }}">{{ minor_versions[0].version }}</a> {{- "" -}}
-                        </li>
+                        <a class="ver-link" href="{{ minor_versions[0].url }}">{{ minor_versions[0].version }}</a> {{- "" -}}
                     {%- else -%}
                         <li> {{- "" -}}
-                            <span class="{{ 'active' if minor == current_minor else '' }}">{{ minor }}</span> {{- "" -}}
-                            <ul>
-                                {%- for v in minor_versions -%}
-                                    <li class="li-link {{ 'active' if v.version == current_tag else '' }}"> {{- "" -}}
-                                        <a href="{{ v.url }}">{{ v.version }}</a> {{- "" -}}
-                                    </li>
-                                {%- endfor -%}
-                            </ul> {{- "" -}}
+                            <span {{ 'class=\"active\"' if minor == current_minor else '' }}>{{ minor }}</span> {{- "" -}}
+                            <div class="ver-links">
+                            {%- for v in minor_versions -%}
+                                <a href="{{ v.url }}"{{ ' class=\"active\"' if v.version == current_tag else '' }}>{{- v.version -}}</a>
+                            {%- endfor -%}
+                            </div> {{- "" -}}
                         </li>
                     {%- endif -%}
                 {%- endfor -%}
                 </ul> {{- "" -}}
             </li>
             {%- endfor -%}
+
         </ul>
 
         <div class="filter-results"></div>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -20,33 +20,31 @@
         <h3 class="screenreader">Versions</h3>
         <ul class="versions">
             {% set current_major, current_minor, current_version = current_version_path %}
-            {% for major, major_versions in (versions|default({})).items() %}
-            <li>
-                <span class="{{ 'active' if current_major == major else '' }}">{{ major }}</span>
+            {%- for major, major_versions in (versions|default({})).items() -%}
+            <li> {{- "" -}}
+                <span class="{{ 'active' if current_major == major else '' }}">{{ major }}</span> {{- "" -}}
                 <ul>
-                {% for minor, minor_versions in major_versions.items() %}
-                    {% if minor == minor_versions[0] and minor_versions|length == 1 %}
-                        <li class="li-link">
-                            <a href="{{ minor_versions[0].url }}">{{ minor_versions[0].version }}</a>
+                {%- for minor, minor_versions in major_versions.items() -%}
+                    {%- if minor == minor_versions[0] and minor_versions|length == 1 -%}
+                        <li class="li-link"> {{- "" -}}
+                            <a href="{{ minor_versions[0].url }}">{{ minor_versions[0].version }}</a> {{- "" -}}
                         </li>
-                    {% else %}
-                        <li>
-                            <span class="{{ 'active' if minor == current_minor else '' }}">{{ minor }}</span>
+                    {%- else -%}
+                        <li> {{- "" -}}
+                            <span class="{{ 'active' if minor == current_minor else '' }}">{{ minor }}</span> {{- "" -}}
                             <ul>
-                                {% for v in minor_versions %}
-                                    <li class="li-link {{ 'active' if v.version == current_tag else '' }}">
-                                        <a href="{{ v.url }}">
-                                            {{ v.version }}
-                                        </a>
+                                {%- for v in minor_versions -%}
+                                    <li class="li-link {{ 'active' if v.version == current_tag else '' }}"> {{- "" -}}
+                                        <a href="{{ v.url }}">{{ v.version }}</a> {{- "" -}}
                                     </li>
-                                {% endfor %}
-                            </ul>
+                                {%- endfor -%}
+                            </ul> {{- "" -}}
                         </li>
-                    {% endif %}
-                {% endfor %}
-                </ul>
+                    {%- endif -%}
+                {%- endfor -%}
+                </ul> {{- "" -}}
             </li>
-        {% endfor %}
+            {%- endfor -%}
         </ul>
 
         <div class="filter-results"></div>


### PR DESCRIPTION
From commit message:

Due to redundant whitespace, HTML of versions list with all Linux
tags (including tags that are normally filtered away) takes around
2 megabytes.

This commit aims to reduce that number by removing all whitespace from
the sidebar.
This cut the size of the versions list HTML to around 300 kilobytes.

---

Further improvement could be made by simplifying links that redirect to a different repository version. 
Currently, version links grow the deeper user is in the repository tree.

For example, a short query parameter could be introduced. 
If this parameter would be present in the URL, backend could generate a redirect to URL with the target version version.
Version links could then just contain a relative URL with just the query parameter, instead of a relative-from-root URL that grows the with the file path.

Note that with this solution, if someone copies a link from the sidebar, the link structure will be rather confusing. This probably can be fixed a bit of javascript that would replace short links with full links on hover. 