### PR TITLE
script/query: don't restrict `./script.sh get-latest` to a single tag

### DIFF
--- a/elixir/query.py
+++ b/elixir/query.py
@@ -110,18 +110,16 @@ class Query:
 
         elif cmd == 'latest':
 
-            previous = None
-            index = 0
+            # Returns the latest tag that is included in the database.
+            # This excludes release candidates.
+            sorted_tags = self.scriptLines('get-latest-tags')
 
-            while True:
-                tag = decode(self.script('get-latest', str(index))).rstrip('\n')
-
-                # tag == previous implies oldest tag, we return it anyway
-                if self.db.vers.exists(tag) or tag == previous:
+            for tag in sorted_tags:
+                if self.db.vers.exists(tag):
                     return tag
 
-                previous = tag
-                index += 1
+            # return the oldest tag, even if it does not exist in the database
+            return sorted_tags[-1]
 
         elif cmd == 'type':
 

--- a/script.sh
+++ b/script.sh
@@ -63,9 +63,9 @@ list_tags_h()
     sed -r 's/^(v[0-9]*)\.([0-9]*)(.*)$/\1 \1.\2 \1.\2\3/'
 }
 
-get_latest()
+get_latest_tags()
 {
-    git tag | version_dir | grep -v '\-rc' | sort -V | tail -n $(($opt1 + 1)) | head -1
+    git tag | version_dir | grep -v '\-rc' | sort -Vr
 }
 
 get_type()
@@ -247,8 +247,8 @@ case $cmd in
         fi
         ;;
 
-    get-latest)
-        get_latest
+    get-latest-tags)
+        get_latest_tags
         ;;
 
     get-type)


### PR DESCRIPTION
While fixing #349 I noticed the oddity that was `script.sh get-latest`. On one side we have `script.sh` that has access to the full tag list but only returns one, and on the other we have the Python code that spawns multiple time `script.sh` if the tags it gets aren't up to its expectations.

Simplify that by making `script.sh` return the full sorted list of tags. Then we let Python code do its filtering based on database content. Code is more straight forward that way.

---

Merged 3d81fa4e4ebc25f2ad3d6c8bc344596162cfba89 quickly to fix the ugly user-facing bug, but this is refactoring so let's do a round of review.

---

*Commit message:*

`./script.sh get-latest <offset>` gets the full list of tags, filters it, sorts it then returns a single result. On the Python side, it gets the first one. If that works, it uses it, else it tries the second one, etc.

That is a weird implementation: modify get-latest to return all tags so that Python code only has to spawn a single subprocess.

Also, rename it from `get-latest` to `get-latest-tags`. This makes things more explicit (what latest?) and also explicits that more than one tag is required.