### PR TITLE
Fix docker build command in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -290,7 +290,7 @@ Dockerfiles are provided in the `docker/` directory.
 To build the image, run the following commands:
 
  # git clone https://github.com/bootlin/elixir.git ./elixir
- # docker build -t elixir --build-arg ELIXIR_VERSION=`git rev-parse --short HEAD` ./elixir/Dockerfile ./elixir
+ # docker build -t elixir --build-arg ELIXIR_VERSION=`git rev-parse --short HEAD` -f ./elixir/docker/Dockerfile ./elixir
 
 ELIXIR_VER build argument is optional. Since .git directory is not copied into Docker image by default,
 the option is used to pass a version string to Elixir.


### PR DESCRIPTION
I needed to specify `-f` and fix the Dockerfile path while following the README instructions. I'm using Docker version 27.2.1, build 9e34c9b.