### PR TITLE
Fix typos

### DIFF
--- a/elixir/filters/cpppathinc.py
+++ b/elixir/filters/cpppathinc.py
@@ -24,7 +24,7 @@ class CppPathIncFilter(Filter):
             inc = m.group(3)
             if re.match('^asm/.*', inc):
                 # Keep the original string in case the path contains "asm/"
-                # Because there are then multiple include possibilites, one per architecture
+                # Because there are then multiple include possibilities, one per architecture
                 return m.group(0)
             else:
                 self.cpppathinc.append(inc)

--- a/elixir/filters/dtscompcode.py
+++ b/elixir/filters/dtscompcode.py
@@ -2,7 +2,7 @@ import re
 from .utils import Filter, FilterContext, encode_number, decode_number, extension_matches
 
 # Filter for DT compatible strings in code (C family) files
-# Finds assigments to properties and variables named 'compatible' and recognized by the Query.query('file')
+# Finds assignments to properties and variables named 'compatible' and recognized by the Query.query('file')
 # .compatible = "device"
 # Example: u-boot/v2023.10/source/drivers/phy/nop-phy.c#L84
 class DtsCompCodeFilter(Filter):

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -215,7 +215,7 @@ class IndexResource:
         return
 
 # Handles source URLs
-# Path parameters are asssumed to be unquoted by converters
+# Path parameters are assumed to be unquoted by converters
 class SourceResource:
     def on_get(self, req, resp, project, version, path):
         project, version, query = validate_project_and_version(req.context, project, version)
@@ -303,7 +303,7 @@ class IdentPostRedirectResource:
 
 # Handles ident URLs when family is specified in the URL, both POST and GET
 # See IdentPostRedirectResource for behavior on POST
-# Path parameters are asssumed to be unquoted by converters
+# Path parameters are assumed to be unquoted by converters
 class IdentResource(IdentPostRedirectResource):
     def on_get(self, req, resp, project, version, family, ident):
         project, version, query = validate_project_and_version(req.context, project, version)
@@ -412,7 +412,7 @@ def get_versions_cached(q, ctx, project):
 
         return cached_versions[1]
 
-# Retruns template context used by the layout template
+# Returns template context used by the layout template
 # q: Query object
 # ctx: RequestContext object
 # get_url_with_new_version: see get_url parameter of get_versions

--- a/find-file-doc-comments.pl
+++ b/find-file-doc-comments.pl
@@ -105,7 +105,7 @@ sub main {
         --$lineno;
 
         # TODO make sure we're not still in the definition.
-        # E.g., memblock.h:for_each_mem_range().  The defintion is reported
+        # E.g., memblock.h:for_each_mem_range().  The definition is reported
         # on the second line of the #define, not the first line.
 
         say "  Starting search for docs at line $lineno" if $VERBOSE;

--- a/t/tree/arch/arm/xen/hypercall.S
+++ b/t/tree/arch/arm/xen/hypercall.S
@@ -32,9 +32,9 @@
 
 /*
  * The Xen hypercall calling convention is very similar to the ARM
- * procedure calling convention: the first paramter is passed in r0, the
+ * procedure calling convention: the first parameter is passed in r0, the
  * second in r1, the third in r2 and the fourth in r3. Considering that
- * Xen hypercalls have 5 arguments at most, the fifth paramter is passed
+ * Xen hypercalls have 5 arguments at most, the fifth parameter is passed
  * in r4, differently from the procedure calling convention of using the
  * stack for that case.
  *

--- a/t/tree/drivers/firmware/broadcom/bcm74xx_sprom.c
+++ b/t/tree/drivers/firmware/broadcom/bcm74xx_sprom.c
@@ -403,7 +403,7 @@ static void bcm47xx_sprom_fill_auto(struct ssb_sprom *sprom,
 	ENTRY(0x00000700, u8, pre, "noiselvl5gua1", noiselvl5gua[1], 0, fb);
 	ENTRY(0x00000700, u8, pre, "noiselvl5gua2", noiselvl5gua[2], 0, fb);
 }
-#undef ENTRY /* It's specififc, uses local variable, don't use it (again). */
+#undef ENTRY /* It's specific, uses local variable, don't use it (again). */
 
 static void bcm47xx_fill_sprom_path_r4589(struct ssb_sprom *sprom,
 					  const char *prefix, bool fallback)

--- a/t/tree/drivers/i2c/i2c-core-smbus.c
+++ b/t/tree/drivers/i2c/i2c-core-smbus.c
@@ -4,7 +4,7 @@
  *
  * This file contains the SMBus functions which are always included in the I2C
  * core because they can be emulated via I2C. SMBus specific extensions
- * (e.g. smbalert) are handled in a seperate i2c-smbus module.
+ * (e.g. smbalert) are handled in a separate i2c-smbus module.
  *
  * All SMBus-related things are written by Frodo Looijaard <frodol@dds.nl>
  * SMBus 2.0 support by Mark Studebaker <mdsxyz123@yahoo.com> and

--- a/t/tree/include/linux/acpi.h
+++ b/t/tree/include/linux/acpi.h
@@ -583,7 +583,7 @@ enum acpi_predicate {
 	greater_than_or_equal,
 };
 
-/* Table must be terminted by a NULL entry */
+/* Table must be terminated by a NULL entry */
 struct acpi_platform_list {
 	char	oem_id[ACPI_OEM_ID_SIZE+1];
 	char	oem_table_id[ACPI_OEM_TABLE_ID_SIZE+1];

--- a/t/tree/include/linux/of.h
+++ b/t/tree/include/linux/of.h
@@ -1038,7 +1038,7 @@ static inline bool of_node_is_type(const struct device_node *np, const char *typ
  * @propname:	name of the property to be searched.
  *
  * Search for a property in a device node and count the number of u8 elements
- * in it. Returns number of elements on sucess, -EINVAL if the property does
+ * in it. Returns number of elements on success, -EINVAL if the property does
  * not exist or its length does not match a multiple of u8 and -ENODATA if the
  * property does not have a value.
  */
@@ -1055,7 +1055,7 @@ static inline int of_property_count_u8_elems(const struct device_node *np,
  * @propname:	name of the property to be searched.
  *
  * Search for a property in a device node and count the number of u16 elements
- * in it. Returns number of elements on sucess, -EINVAL if the property does
+ * in it. Returns number of elements on success, -EINVAL if the property does
  * not exist or its length does not match a multiple of u16 and -ENODATA if the
  * property does not have a value.
  */
@@ -1072,7 +1072,7 @@ static inline int of_property_count_u16_elems(const struct device_node *np,
  * @propname:	name of the property to be searched.
  *
  * Search for a property in a device node and count the number of u32 elements
- * in it. Returns number of elements on sucess, -EINVAL if the property does
+ * in it. Returns number of elements on success, -EINVAL if the property does
  * not exist or its length does not match a multiple of u32 and -ENODATA if the
  * property does not have a value.
  */
@@ -1089,7 +1089,7 @@ static inline int of_property_count_u32_elems(const struct device_node *np,
  * @propname:	name of the property to be searched.
  *
  * Search for a property in a device node and count the number of u64 elements
- * in it. Returns number of elements on sucess, -EINVAL if the property does
+ * in it. Returns number of elements on success, -EINVAL if the property does
  * not exist or its length does not match a multiple of u64 and -ENODATA if the
  * property does not have a value.
  */

--- a/t/tree/include/linux/plist.h
+++ b/t/tree/include/linux/plist.h
@@ -44,7 +44,7 @@
  *
  * The nodes on the prio_list list are sorted by priority to simplify
  * the insertion of new nodes. There are no nodes with duplicate
- * priorites on the list.
+ * priorities on the list.
  *
  * The nodes on the node_list are ordered by priority and can contain
  * entries which have the same priority. Those entries are ordered

--- a/t/tree/include/linux/radix-tree.h
+++ b/t/tree/include/linux/radix-tree.h
@@ -367,7 +367,7 @@ radix_tree_chunk_size(struct radix_tree_iter *iter)
  * radix_tree_next_slot - find next slot in chunk
  *
  * @slot:	pointer to current slot
- * @iter:	pointer to interator state
+ * @iter:	pointer to iterator state
  * @flags:	RADIX_TREE_ITER_*, should be constant
  * Returns:	pointer to next slot, or NULL if there no more left
  *


### PR DESCRIPTION
There are some typos in documentation, comments, etc.

Fix them via codespell.
