### PR TITLE
js: remove 301 redirect cache fix

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -319,27 +319,6 @@ function setupGoToTop() {
   });
 }
 
-// fix incorrectly issued 301 redirect
-// https://developer.mozilla.org/en-US/docs/Web/API/Request/cache
-// https://developer.mozilla.org/en-US/docs/Web/API/Request/redirect
-// TODO: remove after 10.2024
-function fix301() {
-  let path = location.pathname.split('/');
-  if (path.length == 4) {
-    path[2] = 'latest';
-    let newPath = path.join('/');
-    fetch(newPath, {
-        cache: 'reload',
-        redirect: 'manual',
-        // this is to make sure that varnish will cache the response,
-        // by default fetch sends no-cache in both headers if cache='reload'
-        headers: {'Cache-Control': 'max-age=86400', 'Pragma': ''}
-    })
-      .then(console.log)
-      .catch(console.error);
-  }
-}
-
 function randomChoice(arr) {
   return arr[Math.floor(Math.random() * arr.length)];
 }
@@ -425,5 +404,4 @@ document.addEventListener('DOMContentLoaded', _ => {
   setupAutoscrollingPrevention();
   setupAnchorOffsetHandler();
   setupGoToTop();
-  fix301();
 });

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -75,7 +75,7 @@
                 </span>
             </footer>
         </div>
-        <script src="/static/script.js?v=15"></script>
+        <script src="/static/script.js?v=16"></script>
         <script src="/static/dynamic-references.js?v=4"></script>
         <script src="/static/autocomplete.js" project="{{ current_project }}"></script>
     </body>


### PR DESCRIPTION
This code was required because we messed-up in the past regarding caching headers. This is not required anymore because the caching set has expired, so no well behaving user-agent should have remains.

This represents something like 240k requests to the backend (not the cache) over two weeks. Server load was minimal because generating those responses is really fast.