### PR TITLE
find-file-doc-comments.pl: no "uninitialized value source_lines[0]"

### DIFF
--- a/find-file-doc-comments.pl
+++ b/find-file-doc-comments.pl
@@ -32,6 +32,7 @@ exit main(@ARGV);
 sub main {
     die "Need a filename" unless @_;
     my $filename = shift;
+    die "Could not read $filename" unless -r $filename;
     say "Processing file $filename" if $VERBOSE;
 
     # Fatalize all warnings, and log which file triggered the warning.

--- a/find-file-doc-comments.pl
+++ b/find-file-doc-comments.pl
@@ -105,6 +105,9 @@ sub main {
         # back to it manually.  Move to the first line that might be a doc comment.
         --$lineno;
 
+        # If we ran off the beginning of the file, there's no doc comment.
+        next if $lineno <= 0;
+
         # TODO make sure we're not still in the definition.
         # E.g., memblock.h:for_each_mem_range().  The defintion is reported
         # on the second line of the #define, not the first line.


### PR DESCRIPTION
This is the alternative I propose to #274.  On my system, it fixes the test cases given at:
 * https://github.com/bootlin/elixir/issues/232#issuecomment-1345366861 
 * https://github.com/bootlin/elixir/pull/274#issue-2152308268