### PR TITLE
Dockerfile: move `COPY . /usr/local/elixir/` to be the last step

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,6 @@ RUN python3 -m venv venv && \
 
 RUN mkdir -p /srv/elixir-data/
 
-COPY . /usr/local/elixir/
 COPY ./docker/000-default.conf /etc/apache2/sites-available/000-default.conf
 COPY ./docker/gitconfig /etc/gitconfig
 
@@ -59,5 +58,7 @@ ENV ELIXIR_VERSION=$ELIXIR_VERSION \
     ELIXIR_ROOT=/srv/elixir-data \
     PATH="/usr/local/elixir/utils:/usr/local/elixir/venv/bin:$PATH" \
     PYTHONUNBUFFERED=1
+
+COPY . /usr/local/elixir/
 
 ENTRYPOINT ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]


### PR DESCRIPTION
On my machine, a `docker build` after any file change is:
 - Before this patch: 7.29s
 - Afterwards:        2.18s

I don't think there is any risk (that means the files aren't there when we run `a2enmod rewrite`).