### PR TITLE
web: Redirect on incomplete URLs

### DIFF
--- a/elixir/query.py
+++ b/elixir/query.py
@@ -116,10 +116,10 @@ class Query:
 
             for tag in sorted_tags:
                 if self.db.vers.exists(tag):
-                    return tag
+                    return tag.decode()
 
             # return the oldest tag, even if it does not exist in the database
-            return sorted_tags[-1]
+            return sorted_tags[-1].decode()
 
         elif cmd == 'type':
 

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -359,6 +359,17 @@ class IncompleteURLRedirectResource:
         resp.status = falcon.HTTP_FOUND
         resp.location = stringify_source_path(project, version, '/')
 
+# Handles /{project}/{version}/... URLs with unknown "command"
+class UnknownPathResource:
+    def on_get(self, req, resp, project: str, version: str, family: str = "", subcmd: str = "", path: str = ""):
+        project, version, query = validate_project_and_version(req.context, project, version)
+
+        raise ElixirProjectError('Error', 'Invalid path',
+                          project=project, version=version, query=query,
+                          extra_template_args={
+                              'current_family': 'A',
+                          })
+
 
 # File families available in the dropdown next to search input in the topbar
 TOPBAR_FAMILIES = {
@@ -808,6 +819,9 @@ def get_application():
     app.add_route('/{project}', IncompleteURLRedirectResource())
     app.add_route('/{project}/{version}', IncompleteURLRedirectResource())
     app.add_route('/{project}/{version}/', IncompleteURLRedirectResource())
+    app.add_route('/{project}/{version}/{family}', UnknownPathResource())
+    app.add_route('/{project}/{version}/{family}/{subcmd}', UnknownPathResource())
+    app.add_route('/{project}/{version}/{family}/{subcmd}/{path:path}', UnknownPathResource())
 
     return app
 

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -210,7 +210,7 @@ class IndexResource:
             raise ElixirProjectError('Error', f'Unknown default project: {project}',
                                      status=falcon.HTTP_INTERNAL_SERVER_ERROR)
 
-        version = parse.quote(query.query('latest'))
+        version = query.query('latest')
         resp.status = falcon.HTTP_FOUND
         resp.location = stringify_source_path(project, version, '/')
         return
@@ -235,7 +235,7 @@ class SourceResource:
                               project=project, version=version, query=query)
 
         if version == 'latest':
-            version = parse.quote(query.query('latest'))
+            version = query.query('latest')
             resp.status = falcon.HTTP_FOUND
             resp.location = stringify_source_path(project, version, path)
             return
@@ -326,7 +326,7 @@ class IdentResource(IdentPostRedirectResource):
         ident = validated_ident
 
         if version == 'latest':
-            version = parse.quote(query.query('latest'))
+            version = query.query('latest')
             resp.status = falcon.HTTP_FOUND
             resp.location = stringify_ident_path(project, version, family, ident)
             return
@@ -354,7 +354,7 @@ class IncompleteURLRedirectResource:
                                      status=falcon.HTTP_INTERNAL_SERVER_ERROR)
 
         if version == 'latest' or len(version) == 0:
-            version = parse.quote(query.query('latest'))
+            version = query.query('latest')
 
         resp.status = falcon.HTTP_FOUND
         resp.location = stringify_source_path(project, version, '/')

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -94,6 +94,7 @@ def get_project_error_page(req, resp, exception: ElixirProjectError):
 
         'referer': req.referer if req.referer != req.uri else None,
         'bug_report_link': get_github_issue_link(report_error_details),
+        'home_page_link': '/',
         'report_error_details': report_error_details,
 
         'error_title': exception.title,
@@ -109,25 +110,24 @@ def get_project_error_page(req, resp, exception: ElixirProjectError):
         get_url_with_new_version = lambda v: stringify_source_path(project, v, '/')
         versions, current_version_path = get_versions(versions_raw, get_url_with_new_version, version)
 
+        if current_version_path[2] is None:
+            # If details about current version are not available, make base links
+            # point to latest.
+            # current_tag is not set to latest to avoid latest being highlighted in the sidebar
+            version = query.query('latest').decode()
+
         template_ctx = {
             **template_ctx,
 
             'current_project': project,
+            'current_tag': version,
             'versions': versions,
             'current_version_path': current_version_path,
+
+            'home_page_link': get_source_base_url(project, version),
+            'source_base_url': get_source_base_url(project, version),
+            'ident_base_url': get_ident_base_url(project, version),
         }
-
-
-        if version is None:
-            # If details about current version are not available, make base links
-            # point to latest.
-            # current_tag is not set to latest to avoid latest being highlighted in the sidebar
-            version = query.query('latest')
-        else:
-            template_ctx['current_tag'] = version
-
-        template_ctx['source_base_url'] = get_source_base_url(project, version)
-        template_ctx['ident_base_url'] = get_ident_base_url(project, version)
 
     if exception.description is not None:
         template_ctx['error_details'] = exception.description

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -114,7 +114,7 @@ def get_project_error_page(req, resp, exception: ElixirProjectError):
             # If details about current version are not available, make base links
             # point to latest.
             # current_tag is not set to latest to avoid latest being highlighted in the sidebar
-            version = query.query('latest').decode()
+            version = query.query('latest')
 
         template_ctx = {
             **template_ctx,

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -40,12 +40,12 @@ from .autocomplete import AutocompleteResource
 from .api import ApiIdentGetterResource
 from .query import get_query
 from .web_utils import ProjectConverter, IdentConverter, validate_version, validate_project, validate_ident, \
-        get_elixir_version_string, get_elixir_repo_link, RequestContext, Config
+        get_elixir_version_string, get_elixir_repo_url, RequestContext, Config
 
 VERSION_CACHE_DURATION_SECONDS = 2 * 60  # 2 minutes
 ADD_ISSUE_LINK = "https://github.com/bootlin/elixir/issues/new"
 ELIXIR_VERSION_STRING = get_elixir_version_string()
-ELIXIR_REPO_LINK = get_elixir_repo_link(ELIXIR_VERSION_STRING)
+ELIXIR_REPO_LINK = get_elixir_repo_url(ELIXIR_VERSION_STRING)
 
 DEFAULT_PROJECT = 'linux'
 
@@ -70,7 +70,7 @@ def generate_error_details(req, resp, title, details):
            f"Error title: {title}\n" + \
            f"Error details: {details}\n"
 
-def get_github_issue_link(details: str):
+def get_github_issue_url(details: str):
     body = ("TODO: add information on how you reached the error here and " +
             "validate the details below.\n\n" +
             "---\n\n" +
@@ -90,11 +90,11 @@ def get_project_error_page(req, resp, exception: ElixirProjectError):
         'current_family': 'A',
         'source_base_url': '/',
         'elixir_version_string': req.context.config.version_string,
-        'elixir_repo_link': req.context.config.repo_link,
+        'elixir_repo_url': req.context.config.repo_url,
 
         'referer': req.referer if req.referer != req.uri else None,
-        'bug_report_link': get_github_issue_link(report_error_details),
-        'home_page_link': '/',
+        'bug_report_url': get_github_issue_url(report_error_details),
+        'home_page_url': '/',
         'report_error_details': report_error_details,
 
         'error_title': exception.title,
@@ -124,7 +124,7 @@ def get_project_error_page(req, resp, exception: ElixirProjectError):
             'versions': versions,
             'current_version_path': current_version_path,
 
-            'home_page_link': get_source_base_url(project, version),
+            'home_page_url': get_source_base_url(project, version),
             'source_base_url': get_source_base_url(project, version),
             'ident_base_url': get_ident_base_url(project, version),
         }
@@ -157,7 +157,7 @@ def get_error_page(req, resp, exception: ElixirProjectError):
         'source_base_url': '/',
 
         'referer': req.referer,
-        'bug_report_link': ADD_ISSUE_LINK + parse.quote(report_error_details),
+        'bug_report_url': ADD_ISSUE_LINK + parse.quote(report_error_details),
         'report_error_details': report_error_details,
 
         'error_title': exception.title,
@@ -458,7 +458,7 @@ def get_layout_template_context(q: Query, ctx: RequestContext, get_url_with_new_
         'current_version_path': current_version_path,
         'topbar_families': TOPBAR_FAMILIES,
         'elixir_version_string': ctx.config.version_string,
-        'elixir_repo_link': ctx.config.repo_link,
+        'elixir_repo_url': ctx.config.repo_url,
 
         'source_base_url': get_source_base_url(project, version),
         'ident_base_url': get_ident_base_url(project, version),
@@ -602,10 +602,10 @@ def generate_source_page(ctx: RequestContext, q: Query,
     # Generate breadcrumbs
     path_split = path.split('/')[1:]
     path_temp = ''
-    breadcrumb_links = []
+    breadcrumb_urls = []
     for p in path_split:
         path_temp += '/'+p
-        breadcrumb_links.append((p, f'{ source_base_url }{ path_temp }'))
+        breadcrumb_urls.append((p, f'{ source_base_url }{ path_temp }'))
 
     if type == 'tree':
         back_path = os.path.dirname(path[:-1])
@@ -627,7 +627,7 @@ def generate_source_page(ctx: RequestContext, q: Query,
         raise ElixirProjectError('File not found', 'This file does not exist.',
                                  status=falcon.HTTP_NOT_FOUND,
                                  query=q, project=project, version=version,
-                                 extra_template_args={'breadcrumb_links': breadcrumb_links})
+                                 extra_template_args={'breadcrumb_urls': breadcrumb_urls})
 
     # Create titles like this:
     # root path: "Linux source code (v5.5.6) - Bootlin"
@@ -648,7 +648,7 @@ def generate_source_page(ctx: RequestContext, q: Query,
 
         'title_path': title_path,
         'path': path,
-        'breadcrumb_links': breadcrumb_links,
+        'breadcrumb_urls': breadcrumb_urls,
 
         **template_ctx,
     }

--- a/elixir/web_utils.py
+++ b/elixir/web_utils.py
@@ -33,7 +33,7 @@ def get_elixir_version_string():
 
     return ''
 
-def get_elixir_repo_link(version):
+def get_elixir_repo_url(version):
     if re.match('^[0-9a-f]{5,12}$', version) or version.startswith('v'):
         return ELIXIR_REPO_LINK + f'tree/{ version }'
     else:
@@ -43,7 +43,7 @@ def get_elixir_repo_link(version):
 class Config(NamedTuple):
     project_dir: str
     version_string: str
-    repo_link: str
+    repo_url: str
 
 # Basic information about handled request - current Elixir configuration, configured Jinja environment
 # and logger

--- a/templates/error.html
+++ b/templates/error.html
@@ -16,9 +16,9 @@
         {% if referer is not none -%}
             <li><a class="link" href="{{ referer }}">Go back</a></li>
         {%- endif %}
-        <li><a class="link" href="{{ home_page_link }}">Go to home page</a></li>
-        {% if bug_report_link is not none -%}
-            <li><a class="link" href="{{ bug_report_link }}">Report a bug</a></li>
+        <li><a class="link" href="{{ home_page_url }}">Go to home page</a></li>
+        {% if bug_report_url is not none -%}
+            <li><a class="link" href="{{ bug_report_url }}">Report a bug</a></li>
         {%- endif %}
     </ul>
     {% if report_error_details is not none -%}

--- a/templates/error.html
+++ b/templates/error.html
@@ -16,7 +16,7 @@
         {% if referer is not none -%}
             <li><a class="link" href="{{ referer }}">Go back</a></li>
         {%- endif %}
-        <li><a class="link" href="/">Go to home page</a></li>
+        <li><a class="link" href="{{ home_page_link }}">Go to home page</a></li>
         {% if bug_report_link is not none -%}
             <li><a class="link" href="{{ bug_report_link }}">Report a bug</a></li>
         {%- endif %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -69,7 +69,7 @@
                     Top
                 </a>
                 <span class="poweredby">powered by
-                    <a target="_blank" href="{{ elixir_repo_link }}">
+                    <a target="_blank" href="{{ elixir_repo_url }}">
                         Elixir {{ elixir_version_string }}
                     </a>
                 </span>

--- a/templates/topbar.html
+++ b/templates/topbar.html
@@ -2,7 +2,7 @@
     <div class="breadcrumb">
         <a href="#menu" class="open-menu icon-menu screenreader" title="Open Menu">Open Menu</a>
         <a class="project" href="{{ source_base_url }}">/</a>
-        {% for name, url in breadcrumb_links %}
+        {% for name, url in breadcrumb_urls %}
             <a href="{{ url }}">{{ name }}</a>
             {{ '/' if not loop.last else '' }}
         {% endfor %}


### PR DESCRIPTION
Examples:
/linux          -> /linux/{latest_tag}/source
/linux/{tag}    -> /linux/{tag}/source

URLs like the following now have error pages with details:
/musl/v1.2.5/sourc
/musl/v1.2.5/sourc/
/musl/v1.2.5/sourc/asd
/musl/v1.2.5/sourc/asd/
/musl/v1.2.5/sourc/asd/zxc
/musl/v1.2.5/sourc/asd/zxc/
/musl/v1.2.5/sourc/asd/zxc/...

Also fixes issues with "Go to home page" link on the error page.