### PR TITLE
Dockerfile: Build and use ctags 6.1.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,16 +3,21 @@ FROM debian:bookworm AS build
 RUN \
   apt-get update && \
   apt-get --no-install-recommends -y install \
-    python3 \
-    python3-pip \
-    python3-dev \
+    git build-essential pkg-config autoconf automake \
+    python3 python3-pip python3-dev python3-docutils \
     libdb-dev \
-    build-essential
+    libseccomp-dev libjansson-dev libyaml-dev libxml2-dev
 
-WORKDIR /build/
+WORKDIR /build-berkeleydb/
 
 # NOTE wheel version MUST be sycnhronized with requirements.txt
 RUN pip wheel berkeleydb==18.1.10
+
+WORKDIR /build-ctags/
+
+RUN git clone --branch v6.1.0 --depth 1 https://github.com/universal-ctags/ctags.git
+WORKDIR ctags
+RUN ./autogen.sh && ./configure && make -j $(nproc)
 
 FROM debian:bookworm
 
@@ -22,7 +27,6 @@ RUN \
     python3 \
     python3-pip \
     python3-venv \
-    universal-ctags \
     libdb5.3 \
     perl \
     git \
@@ -36,12 +40,14 @@ COPY ./requirements.txt /usr/local/elixir/
 
 WORKDIR /usr/local/elixir/
 
-COPY --from=build /build/berkeleydb-*.whl /tmp/build/
+COPY --from=build /build-berkeleydb/berkeleydb-*.whl /tmp/build/
 
 RUN python3 -m venv venv && \
     . ./venv/bin/activate && \
     pip install /tmp/build/berkeleydb-*.whl && \
     pip install -r requirements.txt
+
+COPY --from=build /build-ctags/ctags/ctags /usr/bin/ctags
 
 RUN mkdir -p /srv/elixir-data/
 


### PR DESCRIPTION
Instead of using the older version packaged in Debian.