### PR TITLE
Diff view

### DIFF
--- a/elixir/diff.py
+++ b/elixir/diff.py
@@ -1,5 +1,8 @@
+import os
 from typing import Generator, Optional, Tuple, List
 from pygments.formatters import HtmlFormatter
+from .query import Query
+from .web_utils import DirectoryEntry
 
 from elixir.query import DiffEntry
 
@@ -151,4 +154,79 @@ def format_diff(filename: str, diff, code: str, code_other: str) -> Tuple[str, s
     )
 
     return pygments.highlight(code, lexer, formatter), pygments.highlight(code_other, lexer, formatter_other)
+
+# Returns a list of DirectoryEntry objects with information about changes between version.
+# base_url: file URLs will be created by appending file path to this URL. It shouldn't end with a slash
+# tag: requested repository tag
+# tag_other: tag to diff with
+# path: path to the directory in the repository
+def diff_directory_entries(q: Query, base_url, tag: str, tag_other: str, path: str) -> list[DirectoryEntry]:
+    dir_entries = []
+
+    # Fetch list of names in both directories
+    names, names_other = {}, {}
+    for line in q.get_dir_contents(tag, path):
+        n = line.split(' ')
+        names[n[1]] = n
+    for line in q.get_dir_contents(tag_other, path):
+        n = line.split(' ')
+        names_other[n[1]] = n
+
+    # Used to sort names - directories first, files second
+    def dir_sort(name):
+        if name in names and names[name][0] == 'tree':
+            return (1, name)
+        elif name in names_other and names_other[name][0] == 'tree':
+            return (1, name)
+        else:
+            return (2, name)
+
+    # Create a sorted list of all unique filenames from both versions
+    all_names = set(names.keys())
+    all_names = all_names.union(names_other.keys())
+    all_names = sorted(all_names, key=dir_sort)
+
+    for name in all_names:
+        data = names.get(name)
+        data_other = names_other.get(name)
+
+        diff_cls = None
+
+        # Added if file only in right version
+        if data is None and data_other is not None:
+            type, name, size, perm, blob_id = data_other
+            diff_cls = 'added'
+        # Removed if file only in left version
+        elif data_other is None and data is not None:
+            type, name, size, perm, blob_id = data
+            diff_cls = 'removed'
+        # If file in both versions
+        elif data is not None and data_other is not None:
+            type_old, name, _, _, blob_id = data
+            type, _, size, perm, blob_id_other = data_other
+            # changed only if blob id is different
+            if blob_id != blob_id_other or type_old != type:
+                diff_cls = 'changed'
+        else:
+            raise Exception("name does not exist " + name)
+
+        file_path = f"{ path }/{ name }"
+
+        if type == 'tree':
+            dir_entries.append(DirectoryEntry('tree', name, file_path,
+                                              f"{ base_url }{ file_path }", None, diff_cls))
+        elif type == 'blob':
+            # 120000 permission means it's a symlink
+            if perm == '120000':
+                dir_path = path if path.endswith('/') else path + '/'
+                link_contents = q.get_file_raw(tag, file_path)
+                link_target_path = os.path.abspath(dir_path + link_contents)
+
+                dir_entries.append(DirectoryEntry('symlink', name, link_target_path,
+                                                  f"{ base_url }{ link_target_path }", size, diff_cls))
+            else:
+                dir_entries.append(DirectoryEntry('blob', name, file_path,
+                                                  f"{ base_url }{ file_path }", size, diff_cls))
+
+    return dir_entries
 

--- a/elixir/diff.py
+++ b/elixir/diff.py
@@ -1,0 +1,154 @@
+from typing import Generator, Optional, Tuple, List
+from pygments.formatters import HtmlFormatter
+
+from elixir.query import DiffEntry
+
+PygmentsSource = Generator[Tuple[int, str], None, None]
+
+# Wraps pygments HtmlFormatter to create a single diff pane, depending on `left` argument
+class DiffFormater(HtmlFormatter):
+    def __init__(self, diff: List[DiffEntry], left: bool, *args, **kwargs):
+        self.diff = diff
+        self.left = left
+        super().__init__(*args[2:], **kwargs)
+
+    # Wraps pygments line (1 if increase line number, html) in span tag with css_class
+    def mark_line(self, line: Tuple[int, str], css_class: str) -> PygmentsSource:
+        yield line[0], f'<span class="{css_class}">{line[1]}</span>'
+
+    # Wraps num pygments lines from source in span tag with css_class
+    def mark_lines(self, source: PygmentsSource, num: int, css_class: str) -> PygmentsSource:
+        i = 0
+        while i < num:
+            try:
+                t, line = next(source)
+            except StopIteration:
+                break
+            if t == 1:
+                yield t, f'<span class="{css_class}">{line}</span>'
+                i += 1
+            else:
+                yield t, line
+
+    # Yields num empty lines
+    def yield_empty(self, num: int) -> PygmentsSource:
+        for _ in range(num):
+            yield 0, '<span class="diff-line">&nbsp;\n</span>'
+
+    # Returns diff entry, number of the entry after it and the start line
+    # of the change in the current pane (left or right).
+    def get_next_diff_line(self, diff_num: int, next_diff_line: Optional[int]) \
+        -> Tuple[Optional[DiffEntry], int, Optional[int]]:
+
+        next_diff = self.diff[diff_num] if len(self.diff) > diff_num else None
+
+        if next_diff is not None:
+            if self.left and next_diff.type in ('-', '+'):
+                next_diff_line = next_diff.left_start
+            elif next_diff.type in ('-', '+'):
+                next_diff_line = next_diff.right_start
+            elif self.left and next_diff.type == '=':
+                next_diff_line = next_diff.left_start
+            elif next_diff.type == '=':
+                next_diff_line = next_diff.right_start
+            else:
+                raise Exception("invalid next diff mode")
+
+        return next_diff, diff_num+1, next_diff_line
+
+    # Wraps Pygments source generator in diff generator
+    def wrap_diff(self, source: PygmentsSource):
+        next_diff, diff_num, next_diff_line = self.get_next_diff_line(0, None)
+
+        linenum = 0
+
+        while True:
+            try:
+                line = next(source)
+            except StopIteration:
+                break
+
+            # If processing line that begins current diff entry
+            if linenum == next_diff_line:
+                if next_diff is not None:
+                    # Yield empty lines in left pane for new lines in right file
+                    if self.left and next_diff.type == '+':
+                        yield from self.yield_empty(next_diff.right_changed)
+                        yield line
+                        linenum += 1
+                    # Yield green source lines in right pane for new lines in right file
+                    elif next_diff.type == '+':
+                        yield from self.mark_line(line, 'line-added')
+                        yield from self.mark_lines(source, next_diff.right_changed-1, 'line-added')
+                        linenum += next_diff.right_changed
+                    # Yield red source lines in left pane for removed lines in right file
+                    elif self.left and next_diff.type == '-':
+                        yield from self.mark_line(line, 'line-removed')
+                        yield from self.mark_lines(source, next_diff.right_changed-1, 'line-removed')
+                        linenum += next_diff.right_changed
+                    # Yield empty lines in right pane for removed lines in right file
+                    elif next_diff.type == '-':
+                        yield from self.yield_empty(next_diff.right_changed)
+                        yield line
+                        linenum += 1
+                    # Yield highlighted source lines or empty lines in left/right pane for lines changed between files
+                    elif next_diff.type == '=':
+                        total = max(next_diff.left_changed, next_diff.right_changed)
+                        to_print = next_diff.left_changed if self.left else next_diff.right_changed
+                        yield from self.mark_line(line, 'line-removed' if self.left else 'line-added')
+                        yield from self.mark_lines(source, to_print-1, 'line-removed' if self.left else 'line-added')
+                        yield from self.yield_empty(total-to_print)
+                        linenum += to_print
+                    else:
+                        yield line
+                        linenum += 1
+
+                next_diff, diff_num, next_diff_line = self.get_next_diff_line(diff_num, next_diff_line)
+            # Otherwise just return the line
+            else:
+                yield line
+                linenum += 1
+
+    def wrap(self, source):
+        return super().wrap(self.wrap_diff(source))
+
+def format_diff(filename: str, diff, code: str, code_other: str) -> Tuple[str, str]:
+    import pygments
+    import pygments.lexers
+    import pygments.formatters
+    from pygments.lexers.asm import GasLexer
+    from pygments.lexers.r import SLexer
+
+    try:
+        lexer = pygments.lexers.guess_lexer_for_filename(filename, code)
+        if filename.endswith('.S') and isinstance(lexer, SLexer):
+            lexer = GasLexer()
+    except pygments.util.ClassNotFound:
+        lexer = pygments.lexers.get_lexer_by_name('text')
+
+    lexer.stripnl = False
+
+    formatter = DiffFormater(
+        diff,
+        True,
+        # Adds line numbers column to output
+        linenos='inline',
+        # Wraps line numbers in link (a) tags
+        anchorlinenos=True,
+        # Wraps each line in a span tag with id='codeline-{line_number}'
+        linespans='codeline',
+    )
+
+    formatter_other = DiffFormater(
+        diff,
+        False,
+        # Adds line numbers column to output
+        linenos='inline',
+        # Wraps line numbers in link (a) tags
+        anchorlinenos=True,
+        # Wraps each line in a span tag with id='codeline-{line_number}'
+        linespans='codeline',
+    )
+
+    return pygments.highlight(code, lexer, formatter), pygments.highlight(code_other, lexer, formatter_other)
+

--- a/elixir/query.py
+++ b/elixir/query.py
@@ -24,8 +24,19 @@ from . import data
 import os
 from collections import OrderedDict
 from urllib import parse
+from collections import namedtuple
+from typing import List, Literal, Tuple
 
 from io import BytesIO
+
+# Single continuous diff change
+# _start - start line counting from 0
+# _changed - number of lines changed, left_changed = 0 if type in ('+', '-')
+# Type:
+# -: removed from right file
+# +: added to right file
+# =: lines changed in both files
+DiffEntry = namedtuple('DiffEntry', 'type, left_start, left_changed, right_start, right_changed')
 
 class SymbolInstance(object):
     def __init__(self, path, line, type=None):
@@ -175,6 +186,9 @@ class Query:
     def get_file_type(self, version, path):
         return decode(self.script('get-type', version, path)).strip()
 
+    def get_blob_id(self, version, path):
+        return decode(self.script('get-blob-id', version, path)).strip()
+
     # Returns identifier search results
     def search_ident(self, version, ident, family):
         # DT bindings compatible strings are handled differently
@@ -197,6 +211,26 @@ class Query:
 
         # return the oldest tag, even if it does not exist in the database
         return sorted_tags[-1].decode()
+
+    # Returns a diff between a file in two versions
+    def get_diff(self, version: str, version_other: str, path: str) -> List[DiffEntry]:
+        data = decode(self.script('get-diff', version, version_other, path)).split('\n')
+        result = []
+        for line in data:
+            if len(line) == 0:
+                continue
+            elif line[0] == '+':
+                left_start, right_start, changes = line[1:].split(':')
+                result.append(DiffEntry('+', int(left_start), 0, int(right_start), int(changes)))
+            elif line[0] == '-':
+                left_start, right_start, changes = line[1:].split(':')
+                result.append(DiffEntry('-', int(left_start), 0, int(right_start), int(changes)))
+            elif line[0] == '=':
+                left_start, left_changed, right_start, right_changed = line[1:].split(':')
+                result.append(DiffEntry('=', int(left_start), int(left_changed), int(right_start), int(right_changed)))
+            else:
+                raise Exception("Invalid line in get-diff: " + line)
+        return result
 
     def get_file_raw(self, version, path):
         return decode(self.script('get-file', version, path))

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -41,7 +41,7 @@ from .autocomplete import AutocompleteResource
 from .api import ApiIdentGetterResource
 from .query import get_query
 from .web_utils import ProjectConverter, IdentConverter, validate_version, validate_project, validate_ident, \
-        get_elixir_version_string, get_elixir_repo_url, RequestContext, Config
+        get_elixir_version_string, get_elixir_repo_url, RequestContext, Config, DirectoryEntry
 from .diff import format_diff
 
 VERSION_CACHE_DURATION_SECONDS = 2 * 60  # 2 minutes
@@ -660,14 +660,6 @@ def generate_diff(q: Query, project: str, version: str, version_other: str, path
         html_code_other_block = f.untransform_formatted_code(filter_ctx_other, html_code_other_block)
 
     return html_code_block, html_code_other_block
-
-# Represents a file entry in git tree
-# type : either tree (directory), blob (file) or symlink
-# name: filename of the file
-# path: path of the file, path to the target in case of symlinks
-# url: absolute URL of the file
-# size: int, file size in bytes, None for directories and symlinks
-DirectoryEntry = namedtuple('DirectoryEntry', 'type, name, path, url, size')
 
 # Returns a list of DirectoryEntry objects with information about files in a directory
 # base_url: file URLs will be created by appending file path to this URL. It shouldn't end with a slash

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -458,6 +458,8 @@ def get_projects(basedir: str) -> list[ProjectEntry]:
 # Used to render version list in the sidebar
 VersionEntry = namedtuple('VersionEntry', 'version, url, diff_url')
 
+VersionPath = namedtuple('VersionPath', 'major, minor, path')
+
 # Takes result of Query.get_versions() and prepares it for the sidebar template.
 #  Returns an OrderedDict with version information and optionally a triple with
 #  (major, minor, version) of current_version. The triple is useful, because sometimes
@@ -470,10 +472,10 @@ VersionEntry = namedtuple('VersionEntry', 'version, url, diff_url')
 def get_versions(versions: OrderedDict[str, OrderedDict[str, str]],
                  get_url: Callable[[str], str],
                  get_diff_url: Optional[Callable[[str], str]],
-                 current_version: str) -> Tuple[dict[str, dict[str, list[VersionEntry]]], Tuple[str|None, str|None, str|None]]:
+                 current_version: str) -> Tuple[dict[str, dict[str, list[VersionEntry]]], VersionPath]:
 
     result = OrderedDict()
-    current_version_path = (None, None, None)
+    current_version_path = VersionPath(None, None, None)
     for major, minor_versions in versions.items():
         for minor, patch_versions in minor_versions.items():
             for v in patch_versions:
@@ -485,9 +487,19 @@ def get_versions(versions: OrderedDict[str, OrderedDict[str, str]],
                     VersionEntry(v, get_url(v), get_diff_url(v) if get_diff_url is not None else None)
                 )
                 if v == current_version:
-                    current_version_path = (major, minor, v)
+                    current_version_path = VersionPath(major, minor, v)
 
     return result, current_version_path
+
+def find_version_path(versions: OrderedDict[str, OrderedDict[str, str]],
+                      version: str) -> VersionPath:
+    for major, minor_verions in versions.items():
+        for minor, patch_versions in minor_verions.items():
+            for v in patch_versions:
+                if v == version:
+                    return VersionPath(major, minor, v)
+
+    return VersionPath(None, None, None)
 
 def get_versions_cached(q, ctx, project):
     with ctx.versions_cache_lock:
@@ -515,6 +527,7 @@ def get_layout_template_context(q: Query, ctx: RequestContext, get_url_with_new_
         'projects': get_projects(ctx.config.project_dir),
         'versions': versions,
         'current_version_path': current_version_path,
+        'other_version_path': (None, None, None),
         'topbar_families': TOPBAR_FAMILIES,
         'elixir_version_string': ctx.config.version_string,
         'elixir_repo_url': ctx.config.repo_url,
@@ -822,7 +835,8 @@ def generate_diff_page(ctx: RequestContext, q: Query,
                 warning = f'Files are the same in {version} and {version_other}.'
             else:
                 missing_version = version_other if type == 'blob' else version
-                warning = f'File does not exist, or is not a file in {missing_version}. ({version} displayed)'
+                shown_version = version if type == 'blob' else version_other
+                warning = f'File does not exist, or is not a file in {missing_version}. ({shown_version} displayed)'
 
             template_ctx = {
                 'code': generate_source(q, project, version if type == 'blob' else version_other, path),
@@ -854,6 +868,7 @@ def generate_diff_page(ctx: RequestContext, q: Query,
         **get_layout_template_context(q, ctx, get_url_with_new_version, get_diff_url, project, version),
         **template_ctx,
 
+        'other_version_path': find_version_path(get_versions_cached(q, ctx, project), version_other),
         'diff_mode_available': True,
         'diff_checked': True,
         'diff_exit_url': stringify_source_path(project, version, path),

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -25,6 +25,7 @@ import re
 import threading
 import time
 import datetime
+import dataclasses
 from collections import OrderedDict, namedtuple
 from re import search, sub
 from typing import Any, Callable, NamedTuple, Tuple
@@ -610,28 +611,40 @@ def generate_diff(q: Query, project: str, version: str, version_other: str, path
     family = getFileFamily(fname)
 
     source_base_url = get_source_base_url(project, version)
+    source_base_url_other = get_source_base_url(project, version_other)
 
-    def get_ident_url(ident, ident_family=None):
-        if ident_family is None:
-            ident_family = family
-        return stringify_ident_path(project, version, ident_family, ident)
+    def generate_get_ident_url(version):
+        def get_ident_url(ident, ident_family=None):
+            if ident_family is None:
+                ident_family = family
+            return stringify_ident_path(project, version, ident_family, ident)
+        return get_ident_url
 
     filter_ctx = FilterContext(
         q,
         version,
         family,
         path,
-        get_ident_url,
+        generate_get_ident_url(version),
         lambda path: f'{ source_base_url }{ "/" if not path.startswith("/") else "" }{ path }',
         lambda rel_path: f'{ source_base_url }{ os.path.dirname(path) }/{ rel_path }',
     )
 
+    filter_ctx_other = dataclasses.replace(filter_ctx,
+        tag=version_other,
+        get_ident_url=generate_get_ident_url(version_other),
+        get_absolute_source_url=lambda path: f'{ source_base_url_other }{ "/" if not path.startswith("/") else "" }{ path }',
+        get_relative_source_url=lambda rel_path: f'{ source_base_url_other }{ os.path.dirname(path) }/{ rel_path }',
+    )
+
     filters = get_filters(filter_ctx, project)
+    filters_other = get_filters(filter_ctx_other, project)
 
     # Apply filters
     for f in filters:
         code = f.transform_raw_code(filter_ctx, code)
-        code_other = f.transform_raw_code(filter_ctx, code_other)
+    for f in filters_other:
+        code_other = f.transform_raw_code(filter_ctx_other, code_other)
 
     html_code_block, html_code_other_block = format_diff(fname, diff, code, code_other)
 
@@ -643,7 +656,8 @@ def generate_diff(q: Query, project: str, version: str, version_other: str, path
 
     for f in filters:
         html_code_block = f.untransform_formatted_code(filter_ctx, html_code_block)
-        html_code_other_block = f.untransform_formatted_code(filter_ctx, html_code_other_block)
+    for f in filters_other:
+        html_code_other_block = f.untransform_formatted_code(filter_ctx_other, html_code_other_block)
 
     return html_code_block, html_code_other_block
 

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+
 #  This file is part of Elixir, a source code cross-referencer.
 #
 #  Copyright (C) 2017--2020 Mikaël Bouillot <mikael.bouillot@bootlin.com>
@@ -28,7 +29,8 @@ import datetime
 import dataclasses
 from collections import OrderedDict, namedtuple
 from re import search, sub
-from typing import Any, Callable, NamedTuple, Tuple
+from typing import Any, Callable, NamedTuple, Optional, Tuple
+from difflib import SequenceMatcher
 from urllib import parse
 import falcon
 import jinja2
@@ -42,7 +44,7 @@ from .api import ApiIdentGetterResource
 from .query import get_query
 from .web_utils import ProjectConverter, IdentConverter, validate_version, validate_project, validate_ident, \
         get_elixir_version_string, get_elixir_repo_url, RequestContext, Config, DirectoryEntry
-from .diff import format_diff
+from .diff import format_diff, diff_directory_entries
 
 VERSION_CACHE_DURATION_SECONDS = 2 * 60  # 2 minutes
 ELIXIR_VERSION_STRING = get_elixir_version_string()
@@ -88,6 +90,7 @@ def get_project_error_page(req, resp, exception: ElixirProjectError):
         'projects': get_projects(req.context.config.project_dir),
         'topbar_families': TOPBAR_FAMILIES,
         'current_version_path': (None, None, None),
+        'other_version_path': (None, None, None),
         'current_family': 'A',
         'source_base_url': '/',
         'elixir_version_string': req.context.config.version_string,
@@ -109,7 +112,7 @@ def get_project_error_page(req, resp, exception: ElixirProjectError):
 
         versions_raw = get_versions_cached(query, req.context, project)
         get_url_with_new_version = lambda v: stringify_source_path(project, v, '/')
-        versions, current_version_path = get_versions(versions_raw, get_url_with_new_version, version)
+        versions, current_version_path = get_versions(versions_raw, get_url_with_new_version, None, version)
 
         if current_version_path[2] is None:
             # If details about current version are not available, make base links
@@ -193,6 +196,10 @@ def validate_project_and_version(ctx, project, version):
 def get_source_base_url(project: str, version: str) -> str:
     return f'/{ parse.quote(project, safe="") }/{ parse.quote(version, safe="") }/source'
 
+def stringify_diff_path(project: str, version: str, version_other: str, path: str) -> str:
+    return f'/{ parse.quote(project, safe="") }/{ parse.quote(version, safe="") }/diff/' + \
+        f'{ parse.quote(version_other, safe="") }/{ path }'
+
 # Converts ParsedSourcePath to a string with corresponding URL path
 def stringify_source_path(project: str, version: str, path: str) -> str:
     if not path.startswith('/'):
@@ -252,6 +259,11 @@ class SourceResource:
 
         query.close()
 
+# Returns base url of diff pages
+# project and version are assumed to be unquoted
+def get_diff_base_url(project: str, version: str, version_other: str) -> str:
+    return f'/{ parse.quote(project, safe="") }/{ parse.quote(version, safe="") }/diff/{ parse.quote(version_other, safe="") }'
+
 # Handles source URLs without a path, ex. '/u-boot/v2023.10/source'.
 # Note lack of trailing slash
 class SourceWithoutPathResource(SourceResource):
@@ -259,7 +271,7 @@ class SourceWithoutPathResource(SourceResource):
         return super().on_get(req, resp, project, version, '')
 
 class DiffResource:
-    def on_get(self, req, resp, project: str, version: str, version_other: str, path: str):
+    def on_get(self, req, resp, project: str, version: str, version_other: str, path: str = ''):
         project, version, query = validate_project_and_version(req.context, project, version)
         version_other = validate_version(parse.unquote(version_other))
         if version_other is None or version_other == 'latest':
@@ -444,7 +456,7 @@ def get_projects(basedir: str) -> list[ProjectEntry]:
 
 # Tuple of version name and URL to chosen resource with that version
 # Used to render version list in the sidebar
-VersionEntry = namedtuple('VersionEntry', 'version, url')
+VersionEntry = namedtuple('VersionEntry', 'version, url, diff_url')
 
 # Takes result of Query.get_versions() and prepares it for the sidebar template.
 #  Returns an OrderedDict with version information and optionally a triple with
@@ -457,6 +469,7 @@ VersionEntry = namedtuple('VersionEntry', 'version, url')
 # current_version: string with currently browsed version
 def get_versions(versions: OrderedDict[str, OrderedDict[str, str]],
                  get_url: Callable[[str], str],
+                 get_diff_url: Optional[Callable[[str], str]],
                  current_version: str) -> Tuple[dict[str, dict[str, list[VersionEntry]]], Tuple[str|None, str|None, str|None]]:
 
     result = OrderedDict()
@@ -468,13 +481,14 @@ def get_versions(versions: OrderedDict[str, OrderedDict[str, str]],
                     result[major] = OrderedDict()
                 if minor not in result[major]:
                     result[major][minor] = []
-                result[major][minor].append(VersionEntry(v, get_url(v)))
+                result[major][minor].append(
+                    VersionEntry(v, get_url(v), get_diff_url(v) if get_diff_url is not None else None)
+                )
                 if v == current_version:
                     current_version_path = (major, minor, v)
 
     return result, current_version_path
 
-# Caches get_versions result in a context object
 def get_versions_cached(q, ctx, project):
     with ctx.versions_cache_lock:
         if project not in ctx.versions_cache:
@@ -493,9 +507,9 @@ def get_versions_cached(q, ctx, project):
 # project: name of the project
 # version: version of the project
 def get_layout_template_context(q: Query, ctx: RequestContext, get_url_with_new_version: Callable[[str], str],
-                                project: str, version: str) -> dict[str, Any]:
+                                get_diff_url: Optional[Callable[[str], str]], project: str, version: str) -> dict[str, Any]:
     versions_raw = get_versions_cached(q, ctx, project)
-    versions, current_version_path = get_versions(versions_raw, get_url_with_new_version, version)
+    versions, current_version_path = get_versions(versions_raw, get_url_with_new_version, get_diff_url, version)
 
     return {
         'projects': get_projects(ctx.config.project_dir),
@@ -670,11 +684,11 @@ def get_directory_entries(q: Query, base_url, tag: str, path: str) -> list[Direc
     lines = q.get_dir_contents(tag, path)
 
     for l in lines:
-        type, name, size, perm = l.split(' ')
+        type, name, size, perm, blob_id = l.split(' ')
         file_path = f"{ path }/{ name }"
 
         if type == 'tree':
-            dir_entries.append(DirectoryEntry('tree', name, file_path, f"{ base_url }{ file_path }", None))
+            dir_entries.append(DirectoryEntry('tree', name, file_path, f"{ base_url }{ file_path }", None, None))
         elif type == 'blob':
             # 120000 permission means it's a symlink
             if perm == '120000':
@@ -682,9 +696,9 @@ def get_directory_entries(q: Query, base_url, tag: str, path: str) -> list[Direc
                 link_contents = q.get_file_raw(tag, file_path)
                 link_target_path = os.path.abspath(dir_path + link_contents)
 
-                dir_entries.append(DirectoryEntry('symlink', name, link_target_path, f"{ base_url }{ link_target_path }", size))
+                dir_entries.append(DirectoryEntry('symlink', name, link_target_path, f"{ base_url }{ link_target_path }", size, None))
             else:
-                dir_entries.append(DirectoryEntry('blob', name, file_path, f"{ base_url }{ file_path }", size))
+                dir_entries.append(DirectoryEntry('blob', name, file_path, f"{ base_url }{ file_path }", size, None))
 
     return dir_entries
 
@@ -739,10 +753,11 @@ def generate_source_page(ctx: RequestContext, q: Query,
         title_path = f'{ path_split[-1] } - { "/".join(path_split) } - '
 
     get_url_with_new_version = lambda v: stringify_source_path(project, v, path)
+    get_diff_url = lambda v_other: stringify_diff_path(project, version, v_other, path)
 
     # Create template context
     data = {
-        **get_layout_template_context(q, ctx, get_url_with_new_version, project, version),
+        **get_layout_template_context(q, ctx, get_url_with_new_version, get_diff_url, project, version),
 
         'title_path': title_path,
         'path': path,
@@ -759,15 +774,15 @@ def generate_diff_page(ctx: RequestContext, q: Query,
                        project: str, version: str, version_other: str, path: str) -> tuple[int, str]:
 
     status = falcon.HTTP_OK
-    source_base_url = get_source_base_url(project, version)
+    diff_base_url = get_diff_base_url(project, version, version_other)
 
     # Generate breadcrumbs
     path_split = path.split('/')[1:]
     path_temp = ''
-    breadcrumb_links = []
+    breadcrumb_urls = []
     for p in path_split:
         path_temp += '/'+p
-        breadcrumb_links.append((p, f'{ source_base_url }{ path_temp }'))
+        breadcrumb_urls.append((p, f'{ diff_base_url }{ path_temp }'))
 
     type = q.get_file_type(version, path)
     type_other = q.get_file_type(version_other, path)
@@ -807,25 +822,18 @@ def generate_diff_page(ctx: RequestContext, q: Query,
                 warning = f'Files are the same in {version} and {version_other}.'
             else:
                 missing_version = version_other if type == 'blob' else version
-                warning = f'File does not exist or is not a file {missing_version}.'
+                warning = f'File does not exist, or is not a file in {missing_version}. ({version} displayed)'
 
             template_ctx = {
                 'code': generate_source(q, project, version if type == 'blob' else version_other, path),
-                'warning': warning
+                'warning': warning,
             }
             template = ctx.jinja_env.get_template('source.html')
     else:
         raise ElixirProjectError('File not found', f'This file does not exist in {version} nor in {version_other}.',
                                  status=falcon.HTTP_NOT_FOUND,
                                  query=q, project=project, version=version,
-                                 extra_template_args={'breadcrumb_links': breadcrumb_links})
-
-    if type_other != 'blob':
-        raise ElixirProjectError('File not found', f'This file is not present in {version_other}.',
-                                 status=falcon.HTTP_NOT_FOUND,
-                                 query=q, project=project, version=version,
-                                 extra_template_args={'breadcrumb_links': breadcrumb_links})
-
+                                 extra_template_args={'breadcrumb_urls': breadcrumb_urls})
 
     # Create titles like this:
     # root path: "Linux source code (v5.5.6) - Bootlin"
@@ -839,20 +847,21 @@ def generate_diff_page(ctx: RequestContext, q: Query,
         title_path = f'{ path_split[-1] } - { "/".join(path_split) } - '
 
     get_url_with_new_version = lambda v: stringify_source_path(project, v, path)
+    get_diff_url = lambda v_other: stringify_diff_path(project, version, v_other, path)
 
-    template = ctx.jinja_env.get_template('diff.html')
-
-    code, code_other = generate_diff(q, project, version, version_other, path)
     # Create template context
     data = {
-        **get_layout_template_context(q, ctx, get_url_with_new_version, project, version),
+        **get_layout_template_context(q, ctx, get_url_with_new_version, get_diff_url, project, version),
         **template_ctx,
 
-        'code': code,
-        'code_other': code_other,
+        'diff_mode_available': True,
+        'diff_checked': True,
+        'diff_exit_url': stringify_source_path(project, version, path),
+
         'title_path': title_path,
         'path': path,
-        'breadcrumb_links': breadcrumb_links,
+        'breadcrumb_urls': breadcrumb_urls,
+        'base_url': diff_base_url,
     }
 
     return (status, template.render(data))
@@ -935,7 +944,7 @@ def generate_ident_page(ctx: RequestContext, q: Query,
     get_url_with_new_version = lambda v: stringify_ident_path(project, v, family, ident)
 
     data = {
-        **get_layout_template_context(q, ctx, get_url_with_new_version, project, version),
+        **get_layout_template_context(q, ctx, get_url_with_new_version, None, project, version),
 
         'searched_ident': ident,
         'current_family': family,
@@ -1017,6 +1026,7 @@ def get_application():
     app.add_route('/{project}/{version}/ident/{ident}', IdentWithoutFamilyResource())
     app.add_route('/{project}/{version}/{family}/ident/{ident}', IdentResource())
     app.add_route('/{project}/{version}/diff/{version_other}/{path:path}', DiffResource())
+    app.add_route('/{project}/{version}/diff/{version_other}', DiffResource())
 
     app.add_route('/acp', AutocompleteResource())
     app.add_route('/api/ident/{project:project}/{ident:ident}', ApiIdentGetterResource())

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -41,6 +41,7 @@ from .api import ApiIdentGetterResource
 from .query import get_query
 from .web_utils import ProjectConverter, IdentConverter, validate_version, validate_project, validate_ident, \
         get_elixir_version_string, get_elixir_repo_url, RequestContext, Config
+from .diff import format_diff
 
 VERSION_CACHE_DURATION_SECONDS = 2 * 60  # 2 minutes
 ELIXIR_VERSION_STRING = get_elixir_version_string()
@@ -255,6 +256,37 @@ class SourceResource:
 class SourceWithoutPathResource(SourceResource):
     def on_get(self, req, resp, project: str, version: str):
         return super().on_get(req, resp, project, version, '')
+
+class DiffResource:
+    def on_get(self, req, resp, project: str, version: str, version_other: str, path: str):
+        project, version, query = validate_project_and_version(req.context, project, version)
+        version_other = validate_version(parse.unquote(version_other))
+        if version_other is None or version_other == 'latest':
+            raise ElixirProjectError('Error', 'Invalid other version', project=project, query=query)
+
+        if not path.startswith('/') and len(path) != 0:
+            path = f'/{ path }'
+
+        if path.endswith('/'):
+            resp.status = falcon.HTTP_MOVED_PERMANENTLY
+            resp.location = stringify_source_path(project, version, path)
+            return
+
+        # Check if path contains only allowed characters
+        if not search('^[A-Za-z0-9_/.,+-]*$', path):
+            raise ElixirProjectError('Error', 'Path contains characters that are not allowed',
+                              project=project, version=version, query=query)
+
+        if version == 'latest':
+            version = parse.quote(query.get_latest_tag())
+            resp.status = falcon.HTTP_FOUND
+            resp.location = stringify_source_path(project, version, path)
+            return
+
+        resp.content_type = falcon.MEDIA_HTML
+        resp.status, resp.text = generate_diff_page(req.context, query, project, version, version_other, path)
+
+        query.close()
 
 
 # Returns base url of ident pages
@@ -513,7 +545,7 @@ def format_code(filename: str, code: str) -> str:
     lexer.stripnl = False
     formatter = pygments.formatters.HtmlFormatter(
         # Adds line numbers column to output
-        linenos=True,
+        linenos='inline',
         # Wraps line numbers in link (a) tags
         anchorlinenos=True,
         # Wraps each line in a span tag with id='codeline-{line_number}'
@@ -560,12 +592,60 @@ def generate_source(q: Query, project: str, version: str, path: str) -> str:
     html_code_block = format_code(fname, code)
 
     # Replace line numbers by links to the corresponding line in the current file
-    html_code_block = sub(r'href="#codeline-(\d+)', 'name="L\\1" id="L\\1" href="#L\\1', html_code_block)
+    html_code_block = sub(r'href="#codeline-(\d+)', 'class="line-link" name="L\\1" id="L\\1" href="#L\\1', html_code_block)
 
     for f in filters:
         html_code_block = f.untransform_formatted_code(filter_ctx, html_code_block)
 
     return html_code_block
+
+def generate_diff(q: Query, project: str, version: str, version_other: str, path: str) -> Tuple[str, str]:
+    code = q.get_tokenized_file(version, path)
+    code_other = q.get_tokenized_file(version_other, path)
+    diff = q.get_diff(version, version_other, path)
+
+    _, fname = os.path.split(path)
+    _, extension = os.path.splitext(fname)
+    extension = extension[1:].lower()
+    family = getFileFamily(fname)
+
+    source_base_url = get_source_base_url(project, version)
+
+    def get_ident_url(ident, ident_family=None):
+        if ident_family is None:
+            ident_family = family
+        return stringify_ident_path(project, version, ident_family, ident)
+
+    filter_ctx = FilterContext(
+        q,
+        version,
+        family,
+        path,
+        get_ident_url,
+        lambda path: f'{ source_base_url }{ "/" if not path.startswith("/") else "" }{ path }',
+        lambda rel_path: f'{ source_base_url }{ os.path.dirname(path) }/{ rel_path }',
+    )
+
+    filters = get_filters(filter_ctx, project)
+
+    # Apply filters
+    for f in filters:
+        code = f.transform_raw_code(filter_ctx, code)
+        code_other = f.transform_raw_code(filter_ctx, code_other)
+
+    html_code_block, html_code_other_block = format_diff(fname, diff, code, code_other)
+
+    # Replace line numbers by links to the corresponding line in the current file
+    html_code_block = sub('href="#codeline-(\d+)',
+                          'class="line-link" name="L\\1" id="L\\1" href="#L\\1', html_code_block)
+    html_code_other_block = sub('href="#codeline-(\d+)',
+                          'class="line-link" name="OL\\1" id="OL\\1" href="#OL\\1', html_code_other_block)
+
+    for f in filters:
+        html_code_block = f.untransform_formatted_code(filter_ctx, html_code_block)
+        html_code_other_block = f.untransform_formatted_code(filter_ctx, html_code_other_block)
+
+    return html_code_block, html_code_other_block
 
 # Represents a file entry in git tree
 # type : either tree (directory), blob (file) or symlink
@@ -663,6 +743,109 @@ def generate_source_page(ctx: RequestContext, q: Query,
         'breadcrumb_urls': breadcrumb_urls,
 
         **template_ctx,
+    }
+
+    return (status, template.render(data))
+
+# Generates response (status code and optionally HTML) of the `diff` route
+def generate_diff_page(ctx: RequestContext, q: Query,
+                       project: str, version: str, version_other: str, path: str) -> tuple[int, str]:
+
+    status = falcon.HTTP_OK
+    source_base_url = get_source_base_url(project, version)
+
+    # Generate breadcrumbs
+    path_split = path.split('/')[1:]
+    path_temp = ''
+    breadcrumb_links = []
+    for p in path_split:
+        path_temp += '/'+p
+        breadcrumb_links.append((p, f'{ source_base_url }{ path_temp }'))
+
+    type = q.get_file_type(version, path)
+    type_other = q.get_file_type(version_other, path)
+    blob_id = q.get_blob_id(version, path)
+    blob_id_other = q.get_blob_id(version_other, path)
+
+    if type == 'tree' or type_other == 'tree':
+        back_path = os.path.dirname(path[:-1])
+        if back_path == '/':
+            back_path = ''
+
+        def generate_warning(type, version):
+            if type == 'blob':
+                return f'{path} is a file in {version}'
+            elif type == '':
+                return f'{path} does not exist in {version}'
+
+        warnings = [generate_warning(type, version), generate_warning(type_other, version)]
+
+        template_ctx = {
+            'dir_entries': diff_directory_entries(q, diff_base_url, version, version_other, path),
+            'back_url': f'{ diff_base_url }{ back_path }' if path != '' else None,
+            'warnings': warnings
+        }
+        template = ctx.jinja_env.get_template('tree.html')
+    elif type == 'blob' or type_other == 'blob':
+        if type == type_other == 'blob' and blob_id != blob_id_other:
+            code, code_other = generate_diff(q, project, version, version_other, path)
+            template_ctx = {
+                'code': code,
+                'code_other': code_other,
+                'other_tag': parse.unquote(version_other),
+            }
+            template = ctx.jinja_env.get_template('diff.html')
+        else:
+            if blob_id == blob_id_other:
+                warning = f'Files are the same in {version} and {version_other}.'
+            else:
+                missing_version = version_other if type == 'blob' else version
+                warning = f'File does not exist or is not a file {missing_version}.'
+
+            template_ctx = {
+                'code': generate_source(q, project, version if type == 'blob' else version_other, path),
+                'warning': warning
+            }
+            template = ctx.jinja_env.get_template('source.html')
+    else:
+        raise ElixirProjectError('File not found', f'This file does not exist in {version} nor in {version_other}.',
+                                 status=falcon.HTTP_NOT_FOUND,
+                                 query=q, project=project, version=version,
+                                 extra_template_args={'breadcrumb_links': breadcrumb_links})
+
+    if type_other != 'blob':
+        raise ElixirProjectError('File not found', f'This file is not present in {version_other}.',
+                                 status=falcon.HTTP_NOT_FOUND,
+                                 query=q, project=project, version=version,
+                                 extra_template_args={'breadcrumb_links': breadcrumb_links})
+
+
+    # Create titles like this:
+    # root path: "Linux source code (v5.5.6) - Bootlin"
+    # first level path: "arch - Linux source code (v5.5.6) - Bootlin"
+    # deeper paths: "Makefile - arch/um/Makefile - Linux source code (v5.5.6) - Bootlin"
+    if path == '':
+        title_path = ''
+    elif len(path_split) == 1:
+        title_path = f'{ path_split[0] } - '
+    else:
+        title_path = f'{ path_split[-1] } - { "/".join(path_split) } - '
+
+    get_url_with_new_version = lambda v: stringify_source_path(project, v, path)
+
+    template = ctx.jinja_env.get_template('diff.html')
+
+    code, code_other = generate_diff(q, project, version, version_other, path)
+    # Create template context
+    data = {
+        **get_layout_template_context(q, ctx, get_url_with_new_version, project, version),
+        **template_ctx,
+
+        'code': code,
+        'code_other': code_other,
+        'title_path': title_path,
+        'path': path,
+        'breadcrumb_links': breadcrumb_links,
     }
 
     return (status, template.render(data))
@@ -826,6 +1009,7 @@ def get_application():
     app.add_route('/{project}/{version}/ident', IdentPostRedirectResource())
     app.add_route('/{project}/{version}/ident/{ident}', IdentWithoutFamilyResource())
     app.add_route('/{project}/{version}/{family}/ident/{ident}', IdentResource())
+    app.add_route('/{project}/{version}/diff/{version_other}/{path:path}', DiffResource())
 
     app.add_route('/acp', AutocompleteResource())
     app.add_route('/api/ident/{project:project}/{ident:ident}', ApiIdentGetterResource())

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -741,6 +741,7 @@ def generate_source_page(ctx: RequestContext, q: Query,
         'title_path': title_path,
         'path': path,
         'breadcrumb_urls': breadcrumb_urls,
+        'diff_mode_available': True,
 
         **template_ctx,
     }

--- a/elixir/web_utils.py
+++ b/elixir/web_utils.py
@@ -88,5 +88,6 @@ class IdentConverter(falcon.routing.BaseConverter):
 # path: path of the file, path to the target in case of symlinks
 # url: absolute URL of the file
 # size: int, file size in bytes, None for directories and symlinks
-DirectoryEntry = namedtuple('DirectoryEntry', 'type, name, path, url, size')
+# diff: file state in a diff - "added", "removed", "changed" or None
+DirectoryEntry = namedtuple('DirectoryEntry', 'type, name, path, url, size, diff')
 

--- a/elixir/web_utils.py
+++ b/elixir/web_utils.py
@@ -2,6 +2,7 @@ import os
 import re
 import logging
 import threading
+from collections import namedtuple
 from urllib import parse
 from typing import Any, Dict, NamedTuple
 import falcon
@@ -80,4 +81,12 @@ class IdentConverter(falcon.routing.BaseConverter):
     def convert(self, value: str) -> str|None:
         value = parse.unquote(value)
         return validate_ident(value)
+
+# Represents a file entry in git tree
+# type : either tree (directory), blob (file) or symlink
+# name: filename of the file
+# path: path of the file, path to the target in case of symlinks
+# url: absolute URL of the file
+# size: int, file size in bytes, None for directories and symlinks
+DirectoryEntry = namedtuple('DirectoryEntry', 'type, name, path, url, size')
 

--- a/script.sh
+++ b/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #  This file is part of Elixir, a source code cross-referencer.
 #
@@ -79,6 +79,12 @@ get_blob()
     git cat-file blob $opt1
 }
 
+get_blob_id()
+{
+    v=`echo $opt1 | version_rev`
+    git ls-tree --format='%(objectname)' "$v" "`denormalize $opt2`" 2>/dev/null
+}
+
 get_file()
 {
     v=`echo $opt1 | version_rev`
@@ -92,6 +98,30 @@ get_dir()
         awk '{print $2" "$5" "$4" "$1}' |
         grep -v ' \.' |
         sort -t ' ' -k 1,1r -k 2,2
+}
+
+# Arguments: version version_other path
+# Generates a short diff of file between versions. The diff does not contain file contents,
+# only information about location of changed lines.
+# One line is generated for each change, and each change is a continuous range of added/removed/changed lines.
+# For lines added: +(start of change in left file)(start of change in right file)(lines changed)
+# For lines removed: -(start of change in left file)(start of change in right file)(lines changed)
+# For lines changed: =(start of change in left file)(lines changed in left file)
+#   (start of change in right file)(lines changed in right file)
+# Lines are numbered starting from 0. May generate empty lines.
+# See man diff for details on the format.
+get_diff()
+{
+    v=`echo $opt1 | version_rev`
+    v_other=`echo $opt2 | version_rev`
+
+    diff \
+        --unchanged-group-format= \
+        --new-group-format="+%de:%dE:%dN%c'\012'" \
+        --old-group-format="-%de:%dE:%dn%c'\012'" \
+        --changed-group-format="=%de:%dn:%dE:%dN%c'\012'" \
+        <(git cat-file blob "$v:`denormalize $opt3`" 2>/dev/null) \
+        <(git cat-file blob "$v_other:`denormalize $opt3`" 2>/dev/null)
 }
 
 tokenize_file()
@@ -259,12 +289,20 @@ case $cmd in
         get_blob
         ;;
 
+    get-blob-id)
+        get_blob_id
+        ;;
+
     get-file)
         get_file
         ;;
 
     get-dir)
         get_dir
+        ;;
+
+    get-diff)
+        get_diff
         ;;
 
     list-blobs)

--- a/script.sh
+++ b/script.sh
@@ -95,7 +95,7 @@ get_dir()
 {
         v=`echo $opt1 | version_rev`
         git ls-tree -l "$v:`denormalize $opt2`" 2>/dev/null |
-        awk '{print $2" "$5" "$4" "$1}' |
+        awk '{print $2" "$5" "$4" "$1" "$3}' |
         grep -v ' \.' |
         sort -t ' ' -k 1,1r -k 2,2
 }

--- a/static/script.js
+++ b/static/script.js
@@ -185,10 +185,10 @@ function addClassToRangeOfElements(first, last, class_name) {
 // Sets up listeners on element that contains line numbers to handle
 // shift-clicks for range highlighting
 function setupLineRangeHandlers() {
-  // Check if page contains the element with line numbers
+  // Check if page contains the element with line numbers and code
   // If not, then likely script is not executed in context of the source page
-  const linenodiv = document.querySelector(".linenodiv");
-  if (linenodiv === null) {
+  const lxrcode = document.querySelectorAll(".lxrcode");
+  if (lxrcode === null) {
     return;
   }
 
@@ -201,7 +201,9 @@ function setupLineRangeHandlers() {
       rangeStartLine = highlightedRange[0];
       rangeEndLine = highlightedRange[1];
       highlightFromTo(rangeStartLine, rangeEndLine);
-      document.getElementById(`L${rangeStartLine}`).scrollIntoView();
+      const wrapper = document.querySelector('.wrapper');
+      const offsetTop = document.getElementById(`L${rangeStartLine}`).offsetTop;
+      wrapper.scrollTop = offsetTop < 100 ? 200 : offsetTop + 100;
     } else if (location.hash !== "" && location.hash[1] === "L") {
       rangeStartLine = parseLineId(location.hash.substring(1));
     }
@@ -214,15 +216,21 @@ function setupLineRangeHandlers() {
 
   parseFromHash();
 
-  linenodiv.addEventListener("click", ev => {
+  lxrcode.forEach(el => el.addEventListener("click", ev => {
     if (ev.ctrlKey || ev.metaKey) {
+      return;
+    }
+    let el = ev.target;
+    if (el.classList.contains('linenos')) {
+      el = el.parentNode;
+    }
+    if (!el.classList.contains('line-link')) {
       return;
     }
     ev.preventDefault();
 
     // Handler is set on the element that contains all line numbers, check if the
     // event is directed at an actual line number element
-    const el = ev.target;
     if (typeof(el.id) !== "string" || el.id[0] !== "L" || el.tagName !== "A") {
       return;
     }
@@ -271,7 +279,7 @@ function setupLineRangeHandlers() {
       highlightFromTo(rangeStartLine, rangeEndLine);
       window.location.hash = `L${rangeStartLine}-L${rangeEndLine}`;
     }
-  });
+  }));
 }
 
 /* Other fixes */

--- a/static/style.css
+++ b/static/style.css
@@ -461,6 +461,38 @@ h2 {
   padding: 0;
 }
 
+#diff-checkbox-label {
+  color: #888;
+}
+
+#diff-exit {
+  color: #888;
+  padding-left: 1em;
+}
+
+#diff-exit:hover {
+  color: #eee;
+  color: #6d7dd2;
+  font-weight: 700;
+}
+
+#diff-checkbox {
+  padding: 1em;
+  margin-bottom: 0.5em;
+}
+
+#diff-checkbox:checked ~ li .version-link-source {
+  display: none;
+}
+
+.version-link-diff {
+  display: none;
+}
+
+#diff-checkbox:checked ~ li .version-link-diff {
+  display: inline;
+}
+
 /* reference popup */
 
 #reference-popup-wrapper {
@@ -765,9 +797,18 @@ h2 {
   display: block;
   padding: 0.15em 1.5em;
 }
+.lxrtree tr {
+  opacity: 1;
+}
 .lxrtree tr:hover {
   background: #ddd;
 }
+
+.lxrtree .warning {
+  opacity: 0.5;
+  margin-left: 1.5em;
+}
+
 .tree-icon:before {
   display: inline-block;
   width: 1.5em;
@@ -788,9 +829,33 @@ h2 {
 }
 
 .size {
-  opacity: 0.6;
+  color: rgba(0, 0, 0, 0.6);
   min-height: 1.5em; /* line_height + 2 * padding = 1.2em + 2 * 0.15em */
   text-align: right;
+}
+
+.file-added {
+  background: #c2ffad;
+}
+
+.lxrtree .file-added:hover {
+  background: #c9e9c0;
+}
+
+.file-removed {
+  background: #fcc0c0;
+}
+
+.lxrtree .file-removed:hover {
+  background: #e7c8c8;
+}
+
+.file-changed {
+  background: #f8edc3;
+}
+
+.lxrtree .file-changed:hover {
+  background: #e5dfca;
 }
 
 
@@ -805,6 +870,19 @@ h2 {
 
 .lxrcode pre * {
   vertical-align: top;
+}
+
+.lxrcode .note-banner {
+  width: 100%;
+  text-align: center;
+  padding: 0.3em;
+  background-color: #e9e9e9;
+  color: #555;
+}
+
+.lxrcode .warning {
+  opacity: 0.5;
+  margin: 1.5em;
 }
 
 .lxrcode .note-banner {

--- a/static/style.css
+++ b/static/style.css
@@ -453,8 +453,11 @@ h2 {
   margin: 0;
 }
 .sidebar nav li.active a {
-  color: #eee;
   color: #6d7dd2;
+  font-weight: 700;
+}
+.sidebar nav li.active-other a {
+  color: #d2c26d;
   font-weight: 700;
 }
 .sidebar nav ul {

--- a/static/style.css
+++ b/static/style.css
@@ -62,7 +62,6 @@ pre {
   font-size: 0.9em;
   line-height: 1.2;
   padding: 0;
-  color: #787878;
 }
 
 table {
@@ -695,6 +694,10 @@ h2 {
   color: gray;
 }
 
+.workspace {
+  position: relative;
+}
+
 /* ident */
 
 .lxrident {
@@ -783,6 +786,7 @@ h2 {
 .tree-icon.icon-back:hover {
   opacity: 1;
 }
+
 .size {
   opacity: 0.6;
   min-height: 1.5em; /* line_height + 2 * padding = 1.2em + 2 * 0.15em */
@@ -792,9 +796,6 @@ h2 {
 
 /* source code */
 
-.lxrcode {
-  position: relative;
-}
 .lxrcode pre {
   margin: 0;
   padding-top: 1em;
@@ -806,6 +807,14 @@ h2 {
   vertical-align: top;
 }
 
+.lxrcode .note-banner {
+  width: 100%;
+  text-align: center;
+  padding: 0.3em;
+  background-color: #e9e9e9;
+  color: #555;
+}
+
 .lxrcode,
 .highlighttable,
 .linenodiv,
@@ -813,12 +822,74 @@ h2 {
   height: 100%;
 }
 
+#L1 {
+  padding-top: 1em;
+}
+
+.diff {
+  display: grid;
+  grid-template-columns: 50% 50%;
+}
+
+.diff-line {
+  display: block;
+}
+
+.diff .highlight pre span:first-child {
+}
+
+.diff .lxrcode pre {
+  padding-top: 0;
+}
+
+.line-added {
+  width: 100%;
+  height: 100%;
+  background: #C2FFAD;
+  display: block;
+}
+
+.line-highlight.line-added .line-link {
+  background: #C2FFAD;
+}
+
+.line-removed {
+  width: 100%;
+  height: 100%;
+  background: #fcc0c0;
+  display: block;
+}
+
+.line-highlight.line-removed .line-link {
+  background: #fcc0c0;
+}
+
 span[id^='codeline-'] {
   display: block;
   padding-left: 1em;
+  width: 100%;
+  height: 100%;
 }
 
-span[id^='codeline-'].line-highlight {
+span[id^='codeline-'] {
+  padding-left: unset;
+}
+
+span[id^='codeline-'] span {
+  display: inline-block;
+}
+
+.line-link {
+  background: #e9e9e9;
+  color: #999;
+  padding-left: 1em;
+  padding-right: 1em;
+  margin-right: 1em;
+  width: 100%;
+  height: 100%;
+}
+
+span.line-highlight {
   width: 100%;
   height: 100%;
   background: #f8edc3;
@@ -835,9 +906,6 @@ span[id^='codeline-'].line-highlight {
   width: 100%;
   scroll-margin: 15vh;
   scroll-margin-top: 15vh;
-}
-.line-highlight {
-  background: #ccc;
 }
 .linenodiv pre a.line-highlight,
 .linenodiv pre span {
@@ -872,6 +940,29 @@ span[id^='codeline-'].line-highlight {
 }
 .highlight .code a:hover {
   border-bottom: 1px dotted #000;
+}
+
+.highlight .source-link,
+.highlight .ident {
+  color: inherit;
+  font-weight: 700;
+  background: linear-gradient(to bottom, #0000 10%, #f4f6ff 10%, #f4f6ff 90%, #0000 90%);
+  border-radius: 0.2em;
+}
+.highlight .line-removed a {
+  background: #fcc0c0;
+}
+.highlight .line-added a {
+  background: #c2ffad;
+}
+.highlight a:hover {
+  border-bottom: 1px dotted #000;
+}
+
+.highlight a .linenos {
+  font-weight: normal;
+  border-radius: 0;
+  background: none;
 }
 
 .code > div {
@@ -950,7 +1041,7 @@ span[id^='codeline-'].line-highlight {
 
 /* highlight */
 
-.highlight .code pre {
+.highlight pre {
   color: #000;
   -moz-tab-size: 8;
   -o-tab-size: 8;
@@ -966,76 +1057,76 @@ span[id^='codeline-'].line-highlight {
   hyphens: none;
 }
 
-.highlight .code .hll { background-color: #ffffcc }
-.highlight .code  { background: #ffffff }
-.highlight .code .c { color: slategray; font-style: italic; } /* Comment */
-.highlight .code .err { color: #FF0000; background-color: #FFAAAA } /* Error */
-.highlight .code .k { color: #008800 } /* Keyword */
-.highlight .code .o { color: #666 } /* Operator */
-.highlight .code .ch { color: #888888 } /* Comment.Hashbang */
-.highlight .code .cm { color: slategray; font-style: italic; } /* Comment.Multiline */
-.highlight .code .cp { color: #557799 } /* Comment.Preproc */
-.highlight .code .cpf { color: #888888 } /* Comment.PreprocFile */
-.highlight .code .c1 { color: slategray; font-style: italic; } /* Comment.Single */
-.highlight .code .cs { color: #cc0000 } /* Comment.Special */
-.highlight .code .gd { color: #A00000 } /* Generic.Deleted */
-.highlight .code .ge { font-style: italic } /* Generic.Emph */
-.highlight .code .gr { color: #FF0000 } /* Generic.Error */
-.highlight .code .gh { color: #000080 } /* Generic.Heading */
-.highlight .code .gi { color: #00A000 } /* Generic.Inserted */
-.highlight .code .go { color: #888888 } /* Generic.Output */
-.highlight .code .gp { color: #c65d09 } /* Generic.Prompt */
-.highlight .code .gs { font-weight: bold } /* Generic.Strong */
-.highlight .code .gu { color: #800080 } /* Generic.Subheading */
-.highlight .code .gt { color: #0044DD } /* Generic.Traceback */
-.highlight .code .kc { color: #008800 } /* Keyword.Constant */
-.highlight .code .kd { color: #008800 } /* Keyword.Declaration */
-.highlight .code .kn { color: #008800 } /* Keyword.Namespace */
-.highlight .code .kp { color: #003388 } /* Keyword.Pseudo */
-.highlight .code .kr { color: #008800 } /* Keyword.Reserved */
-.highlight .code .kt { color: #333399 } /* Keyword.Type */
-.highlight .code .m { color: #6600EE } /* Literal.Number */
-.highlight .code .s { color: #de7f00 } /* Literal.String */
-.highlight .code .na { color: #0000CC } /* Name.Attribute */
-.highlight .code .nb { color: #007020 } /* Name.Builtin */
-.highlight .code .nc { color: #BB0066 } /* Name.Class */
-.highlight .code .no { color: #003366 } /* Name.Constant */
-.highlight .code .nd { color: #555555 } /* Name.Decorator */
-.highlight .code .ni { color: #880000 } /* Name.Entity */
-.highlight .code .ne { color: #FF0000 } /* Name.Exception */
-.highlight .code .nf { color: #0066BB } /* Name.Function */
-.highlight .code .nl { color: #997700 } /* Name.Label */
-.highlight .code .nn { color: #0e84b5 } /* Name.Namespace */
-.highlight .code .nt { color: #007700 } /* Name.Tag */
-.highlight .code .nv { color: #996633 } /* Name.Variable */
-.highlight .code .ow { color: #000000 } /* Operator.Word */
-.highlight .code .p { color: #666 } /* Text.Punctuation */
-.highlight .code .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight .code .mb { color: #6600EE } /* Literal.Number.Bin */
-.highlight .code .mf { color: #6600EE } /* Literal.Number.Float */
-.highlight .code .mh { color: #005588 } /* Literal.Number.Hex */
-.highlight .code .mi { color: #0000DD } /* Literal.Number.Integer */
-.highlight .code .mo { color: #4400EE } /* Literal.Number.Oct */
-.highlight .code .sa { color: #de7f00 } /* Literal.String.Affix */
-.highlight .code .sb { color: #de7f00 } /* Literal.String.Backtick */
-.highlight .code .sc { color: #de7f00 } /* Literal.String.Char */
-.highlight .code .dl { color: #de7f00 } /* Literal.String.Delimiter */
-.highlight .code .sd { color: #a29900 } /* Literal.String.Doc */
-.highlight .code .s2 { color: #de7f00 } /* Literal.String.Double */
-.highlight .code .se { color: #a29900 } /* Literal.String.Escape */
-.highlight .code .sh { color: #de7f00 } /* Literal.String.Heredoc */
-.highlight .code .si { color: #de7f00 } /* Literal.String.Interpol */
-.highlight .code .sx { color: #de7f00 } /* Literal.String.Other */
-.highlight .code .sr { color: #a29900 } /* Literal.String.Regex */
-.highlight .code .s1 { color: #de7f00 } /* Literal.String.Single */
-.highlight .code .ss { color: #a29900 } /* Literal.String.Symbol */
-.highlight .code .bp { color: #007020 } /* Name.Builtin.Pseudo */
-.highlight .code .fm { color: #0066BB } /* Name.Function.Magic */
-.highlight .code .vc { color: #336699 } /* Name.Variable.Class */
-.highlight .code .vg { color: #dd7700 } /* Name.Variable.Global */
-.highlight .code .vi { color: #3333BB } /* Name.Variable.Instance */
-.highlight .code .vm { color: #996633 } /* Name.Variable.Magic */
-.highlight .code .il { color: #0000DD } /* Literal.Number.Integer.Long */
+.highlight .hll { background-color: #ffffcc }
+.highlight  { background: #ffffff }
+.highlight .c { color: slategray; font-style: italic; } /* Comment */
+.highlight .err { color: #FF0000; background-color: #FFAAAA } /* Error */
+.highlight .k { color: #008800 } /* Keyword */
+.highlight .o { color: #666 } /* Operator */
+.highlight .ch { color: #888888 } /* Comment.Hashbang */
+.highlight .cm { color: slategray; font-style: italic; } /* Comment.Multiline */
+.highlight .cp { color: #557799 } /* Comment.Preproc */
+.highlight .cpf { color: #888888 } /* Comment.PreprocFile */
+.highlight .c1 { color: slategray; font-style: italic; } /* Comment.Single */
+.highlight .cs { color: #cc0000 } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080 } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #c65d09 } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080 } /* Generic.Subheading */
+.highlight .gt { color: #0044DD } /* Generic.Traceback */
+.highlight .kc { color: #008800 } /* Keyword.Constant */
+.highlight .kd { color: #008800 } /* Keyword.Declaration */
+.highlight .kn { color: #008800 } /* Keyword.Namespace */
+.highlight .kp { color: #003388 } /* Keyword.Pseudo */
+.highlight .kr { color: #008800 } /* Keyword.Reserved */
+.highlight .kt { color: #333399 } /* Keyword.Type */
+.highlight .m { color: #6600EE } /* Literal.Number */
+.highlight .s { color: #de7f00 } /* Literal.String */
+.highlight .na { color: #0000CC } /* Name.Attribute */
+.highlight .nb { color: #007020 } /* Name.Builtin */
+.highlight .nc { color: #BB0066 } /* Name.Class */
+.highlight .no { color: #003366 } /* Name.Constant */
+.highlight .nd { color: #555555 } /* Name.Decorator */
+.highlight .ni { color: #880000 } /* Name.Entity */
+.highlight .ne { color: #FF0000 } /* Name.Exception */
+.highlight .nf { color: #0066BB } /* Name.Function */
+.highlight .nl { color: #997700 } /* Name.Label */
+.highlight .nn { color: #0e84b5 } /* Name.Namespace */
+.highlight .nt { color: #007700 } /* Name.Tag */
+.highlight .nv { color: #996633 } /* Name.Variable */
+.highlight .ow { color: #000000 } /* Operator.Word */
+.highlight .p { color: #666 } /* Text.Punctuation */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #6600EE } /* Literal.Number.Bin */
+.highlight .mf { color: #6600EE } /* Literal.Number.Float */
+.highlight .mh { color: #005588 } /* Literal.Number.Hex */
+.highlight .mi { color: #0000DD } /* Literal.Number.Integer */
+.highlight .mo { color: #4400EE } /* Literal.Number.Oct */
+.highlight .sa { color: #de7f00 } /* Literal.String.Affix */
+.highlight .sb { color: #de7f00 } /* Literal.String.Backtick */
+.highlight .sc { color: #de7f00 } /* Literal.String.Char */
+.highlight .dl { color: #de7f00 } /* Literal.String.Delimiter */
+.highlight .sd { color: #a29900 } /* Literal.String.Doc */
+.highlight .s2 { color: #de7f00 } /* Literal.String.Double */
+.highlight .se { color: #a29900 } /* Literal.String.Escape */
+.highlight .sh { color: #de7f00 } /* Literal.String.Heredoc */
+.highlight .si { color: #de7f00 } /* Literal.String.Interpol */
+.highlight .sx { color: #de7f00 } /* Literal.String.Other */
+.highlight .sr { color: #a29900 } /* Literal.String.Regex */
+.highlight .s1 { color: #de7f00 } /* Literal.String.Single */
+.highlight .ss { color: #a29900 } /* Literal.String.Symbol */
+.highlight .bp { color: #007020 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #0066BB } /* Name.Function.Magic */
+.highlight .vc { color: #336699 } /* Name.Variable.Class */
+.highlight .vg { color: #dd7700 } /* Name.Variable.Global */
+.highlight .vi { color: #3333BB } /* Name.Variable.Instance */
+.highlight .vm { color: #996633 } /* Name.Variable.Magic */
+.highlight .il { color: #0000DD } /* Literal.Number.Integer.Long */
 
 
 /* layout */
@@ -1235,11 +1326,14 @@ main {
     position: sticky;
     left: 0;
   }
-  .js .linenos {
+  .js .line-link {
     position: -webkit-sticky;
     position: sticky;
     left: 0;
     z-index: 1;
+  }
+  .js .diff .linenos {
+    position: static;
   }
   .js main {
     position: unset;
@@ -1501,7 +1595,7 @@ main {
 }
 .nav-links a:hover {
   color: #fff;
-}
+)}
 
 .social-icons {
   position: absolute;

--- a/templates/diff.html
+++ b/templates/diff.html
@@ -1,0 +1,23 @@
+{% extends "layout.html" %}
+
+{% block title %}
+    {{ title_path }} {{ current_project|capitalize }} diff {{ current_tag }} - Bootlin Elixir Cross Referencer
+{% endblock %}
+
+{% block description -%}
+    Elixir Cross Referencer - diff of {{ current_project|capitalize }} {{ current_tag -}} {{- '' if path|length <= 1 else ': ' + path[1:] }}
+{%- endblock %}
+
+{% block main %}
+<div class="diff">
+    <div class="lxrcode">
+        <div class="note-banner">{{ current_tag }}</div>
+        {{ code }}
+    </div>
+    <div class="lxrcode">
+        <div class="note-banner">{{ other_tag }}</div>
+        {{ code_other }}
+    </div>
+</div>
+{% endblock %}
+

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -28,9 +28,10 @@
             {% endif %}
 
             {% set current_major, current_minor, current_version = current_version_path %}
+            {% set other_major, other_minor, other_version = other_version_path %}
             {% for major, major_versions in (versions|default({})).items() %}
             <li>
-                <span class="{{ 'active' if current_major == major else '' }}">{{ major }}</span>
+                <span class="{{ 'active' if major in (current_major, other_major) else '' }}">{{ major }}</span>
 
                 <ul>
                 {% for minor, minor_versions in major_versions.items() %}
@@ -40,10 +41,13 @@
                         </li>
                     {% else %}
                         <li>
-                            <span class="{{ 'active' if minor == current_minor else '' }}">{{ minor }}</span>
+                            <span class="{{ 'active' if minor in (current_minor, other_minor) else '' }}">{{ minor }}</span>
                             <ul>
                                 {% for v in minor_versions %}
-                                    <li class="li-link {{ 'active' if v.version == current_tag else '' }}">
+                                    <li class="li-link
+                                               {{ 'active' if v.version == current_tag else '' }}
+                                               {{ 'active-other' if v.version == other_tag else '' }}
+                                        ">
                                         <a class="version-link-source" href="{{ v.url }}">
                                             {{ v.version }}
                                         </a>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -19,10 +19,19 @@
 
         <h3 class="screenreader">Versions</h3>
         <ul class="versions">
+            {% if diff_mode_available %}
+                <input id="diff-checkbox" type="checkbox" {% if diff_checked %} checked {% endif %} />
+                <label id="diff-checkbox-label" for="diff-checkbox">Diff mode</label>
+                {% if diff_exit_url %}
+                    <a id="diff-exit" href="{{ diff_exit_url }}">Exit diff mode</a>
+                {% endif %}
+            {% endif %}
+
             {% set current_major, current_minor, current_version = current_version_path %}
             {% for major, major_versions in (versions|default({})).items() %}
             <li>
                 <span class="{{ 'active' if current_major == major else '' }}">{{ major }}</span>
+
                 <ul>
                 {% for minor, minor_versions in major_versions.items() %}
                     {% if minor == minor_versions[0] and minor_versions|length == 1 %}
@@ -35,9 +44,14 @@
                             <ul>
                                 {% for v in minor_versions %}
                                     <li class="li-link {{ 'active' if v.version == current_tag else '' }}">
-                                        <a href="{{ v.url }}">
+                                        <a class="version-link-source" href="{{ v.url }}">
                                             {{ v.version }}
                                         </a>
+                                        {% if v.diff_url is not none %}
+                                            <a class="version-link-diff" href="{{ v.diff_url }}">
+                                                {{ v.version }}
+                                            </a>
+                                        {% endif %}
                                     </li>
                                 {% endfor %}
                             </ul>

--- a/templates/source.html
+++ b/templates/source.html
@@ -10,6 +10,9 @@
 
 {% block main %}
 <div class="lxrcode">
+    {% if warning %}
+        <div class="note-banner">{{ warning }}</div>
+    {% endif %}
     {{ code }}
 </div>
 {% endblock %}

--- a/templates/topbar.html
+++ b/templates/topbar.html
@@ -1,7 +1,7 @@
 <header class="topbar">
     <div class="breadcrumb">
         <a href="#menu" class="open-menu icon-menu screenreader" title="Open Menu">Open Menu</a>
-        <a class="project" href="{{ source_base_url }}">/</a>
+        <a class="project" href="{{ source_base_url if not base_url else base_url }}">/</a>
         {% for name, url in breadcrumb_urls %}
             <a href="{{ url }}">{{ name }}</a>
             {{ '/' if not loop.last else '' }}

--- a/templates/tree.html
+++ b/templates/tree.html
@@ -15,6 +15,11 @@
 {% block main %}
 
 <div class="lxrtree">
+    {% for warning in warnings %}
+        {% if warning is not none %}
+            <div class="warning">Note: {{ warning }}</div>
+        {% endif %}
+    {% endfor %}
     <table>
         <tbody>
         {% if back_url is not none %}
@@ -23,10 +28,10 @@
                 <td><a tabindex="-1" class="size" href="{{ back_url }}"></a></td>
             </tr>
         {% endif %}
-        {% for type, name, path, url, size in dir_entries %}
-            <tr>
+        {% for type, name, path, url, size, diff_cls in dir_entries %}
+            <tr class="{{ "file-"+diff_cls if diff_cls is not none else '' -}}">
                 <td>
-                    <a class="tree-icon icon-{{- type if type != 'symlink' else 'blob' -}}"
+                    <a class="tree-icon icon-{{- type if type != 'symlink' else 'blob' }}"
                        href="{{ url }}">
                     {% if type == 'symlink' %}
                         {{ name }} -> {{  path }}


### PR DESCRIPTION
Note: this is work in progress, not ready for review. Comments are welcome, but I don't expect a full review just yet. Mostly posting this to show that there is some slow progress on this feature. 

Right now, the feature only supports a split diff view. This neatly solves the "which version should an identifier link to" problem. 

How the diffs are generated:
* Take sources of a and b, put both of them through the tokenizer and initial filters
* Take a diff of a and b in a special format (see get_diff in script.sh) that basically only shows where to add empty lines, and which lines to mark as added/deleted
* Pass sources of both files to a subclass of Pygments's HtmlFormatter, that adds empty lines/colorizes lines based on the diff information.

There is a slight efficiency problem with this approach - files can be very similar, but both will get tokenized and formatted separately. And IIRC formatting can take a lot of time.
I don't see a good way of solving that, maybe something smart could be done with the lexer/formatter.
The only optimization that could be worth it, is caching identifiers looked up in the first file for the second file (not implemented yet, and I don't know if it would make sense). I think it would also make sense to limit the size of diffed files - no one should do diffs on the 20 megabytes amdgpu register definitions. 

Closes: #25 