### PR TITLE
Add opensearch manifest for elixir.bootlin.com

### DIFF
--- a/elixir/autocomplete.py
+++ b/elixir/autocomplete.py
@@ -33,6 +33,7 @@ class AutocompleteResource:
         ident_prefix = req.get_param('q')
         family = req.get_param('f')
         project = req.get_param('p')
+        opensearch_mode = req.get_param('opensearch') == 'true'
 
         ident_prefix = validate_ident(ident_prefix)
         if ident_prefix is None:
@@ -83,7 +84,11 @@ class AutocompleteResource:
 
         resp.status = falcon.HTTP_200
         resp.content_type = falcon.MEDIA_JSON
-        resp.media = response
+
+        if not opensearch_mode:
+            resp.media = response
+        else:
+            resp.media = [ident_prefix, response]
 
         query.close()
 

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -383,6 +383,27 @@ class UnknownPathResource:
                           })
 
 
+class OpenSearchManifestResource:
+    def on_get(self, req, resp, project):
+        ctx = req.context
+        query = get_query(ctx.config.project_dir, project)
+        if not query:
+            resp.status = falcon.HTTP_NOT_FOUND
+            resp.content_type = falcon.MEDIA_TEXT
+            resp.text = f'invalid project name: {project}'
+            return
+
+        template = ctx.jinja_env.get_template('search.xml')
+
+        data = {
+            'project_name': project,
+        }
+
+        resp.status = falcon.HTTP_OK
+        resp.content_type = falcon.MEDIA_XML
+        resp.text = template.render(data)
+
+
 # File families available in the dropdown next to search input in the topbar
 TOPBAR_FAMILIES = {
     'A': 'All symbols',
@@ -829,6 +850,8 @@ def get_application():
 
     app.add_route('/acp', AutocompleteResource())
     app.add_route('/api/ident/{project:project}/{ident:ident}', ApiIdentGetterResource())
+
+    app.add_route('/opensearch/{project:project}/search.xml', OpenSearchManifestResource())
 
     app.add_route('/{project}', IncompleteURLRedirectResource())
     app.add_route('/{project}/{version}', IncompleteURLRedirectResource())

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -16,6 +16,7 @@
             {%- endblock %}">
         <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1" />
         <link rel="stylesheet" href="/static/style.css?v=16">
+        <link rel="search" type="application/opensearchdescription+xml" title="Elixir - {{ current_project }}" href="/opensearch/{{ current_project }}/search.xml" />
 
         <link rel="preload" href="/static/img/2penguins.svg" as="image" />
         <link rel="preload" href="/static/img/arrow-dropdown-16.svg" as="image" />

--- a/templates/search.xml
+++ b/templates/search.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Elixir ({{ project_name }})</ShortName>
+  <Description>Elixir Cross Referencer - {{ project_name }}</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Tags>{{ project_name }}</Tags>
+  <Image width="16" height="16" type="image/x-icon">https://elixir.bootlin.com/favicon.ico</Image>
+  <Url rel="results" type="text/html" template="https://elixir.bootlin.com/{{ project_name }}/latest/A/ident/{searchTerms}"/>
+  <Url rel="suggestions" type="application/x-suggestions+json" template="https://elixir.bootlin.com/acp?q={searchTerms}&amp;f=A&amp;p={{ project_name }}&amp;opensearch=true"/>
+  <Url type="application/opensearchdescription+xml" rel="self" template="https://elixir.bootlin.com/opensearch/{{ project_name }}/search.xml" />
+</OpenSearchDescription>


### PR DESCRIPTION
Closes #216 

This adds a static [opensearch](https://developer.mozilla.org/en-US/docs/Web/XML/Guides/OpenSearch) manifest for elixir.bootlin.com. The manifest only works for latest Linux and statically points to elixir.bootlin.com (self hosted instances will need to manually edit the manifest) 