### PR TITLE
Fix recent caching issues

### DIFF
--- a/docker/000-default.conf
+++ b/docker/000-default.conf
@@ -8,6 +8,7 @@
 <Directory /usr/local/elixir/static/>
     AllowOverride None
     Require all granted
+    Header set Cache-Control "max-age=3600"
 </Directory>
 <VirtualHost *:80>
     ServerName MY_LOCAL_IP

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir -p /srv/elixir-data/
 COPY ./docker/000-default.conf /etc/apache2/sites-available/000-default.conf
 COPY ./docker/gitconfig /etc/gitconfig
 
-RUN a2enmod rewrite
+RUN a2enmod rewrite headers
 
 EXPOSE 80
 

--- a/static/script.js
+++ b/static/script.js
@@ -361,7 +361,7 @@ function addBannerContents(bannerElement, msg) {
 }
 
 function updateMessageBanner() {
-  fetch('/static/messages.json')
+  fetch('/static/messages.json?v=1')
     .then(r => r.json())
     .then(messages => {
       const msg = randomChoice(messages);
@@ -372,7 +372,7 @@ function updateMessageBanner() {
 }
 
 function cycleBanner(delay=500) {
-  fetch('/static/messages.json')
+  fetch('/static/messages.json?v=1')
     .then(r => r.json())
     .then(messages => {
       cycleBannerWithData(messages, delay);

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -25,7 +25,7 @@
         <link rel="preload" crossorigin href="/static/fonts/ubuntu/ubuntu-v14-cyrillic_greek_latin_latin-ext_greek-ext_cyrillic-ext-700.woff2" as="font" />
         <link rel="preload" crossorigin href="/static/fonts/ubuntu/ubuntu-v14-cyrillic_greek_latin_latin-ext_greek-ext_cyrillic-ext-italic.woff2" as="font" />
 
-        <link rel="preload" crossorigin href="/static/messages.json" as="fetch" />
+        <link rel="preload" crossorigin href="/static/messages.json?v=1" as="fetch" />
 
         <script>
             document.documentElement.classList.remove('no-js');
@@ -75,7 +75,7 @@
                 </span>
             </footer>
         </div>
-        <script src="/static/script.js?v=16"></script>
+        <script src="/static/script.js?v=17"></script>
         <script src="/static/dynamic-references.js?v=4"></script>
         <script src="/static/autocomplete.js" project="{{ current_project }}"></script>
     </body>


### PR DESCRIPTION
This PR adds a caching header for static files. The header should force browser to cache static files for one hour. 

After a cached file expires, browser usually revalidate it by making a conditional request (If-None-Match, If-Modified-Since). It seems that Apache does support conditional requests - a simple test can be done by reducing the caching time to 10 seconds and browsing Elixir for a while. After every 10 second period, first request to each static file gets a 304, unless the file was modified on the disk. 

The PR also adds ?v to messages URL, and increments ?v on script.js to make sure that browser refresh the messages file.