### PR TITLE
Fix some issues and typos

### DIFF
--- a/elixir/autocomplete.py
+++ b/elixir/autocomplete.py
@@ -68,14 +68,15 @@ class AutocompleteResource:
         # In practice this should mean "the key that starts with provided prefix"
         # See docs about the default comparison function for B-Tree databases:
         # https://docs.oracle.com/cd/E17276_01/html/api_reference/C/dbset_bt_compare.html
-        key, _ = cur.get(query_bytes, DB_SET_RANGE)
-        while i <= 10:
+        result = cur.get(query_bytes, DB_SET_RANGE)
+        while result is not None and i < 10:
+            key, _ = result
             if key.startswith(query_bytes):
                 # If found key starts with the prefix, add to response
                 # and move to the next key
                 i += 1
                 response.append(process(key.decode("utf-8")))
-                key, _ = cur.next()
+                result = cur.next()
             else:
                 # If found key does not start with the prefix, stop
                 break

--- a/elixir/data.py
+++ b/elixir/data.py
@@ -25,8 +25,8 @@ import os
 import os.path
 import errno
 
-deflist_regex = re.compile(b'(\d*)(\w)(\d*)(\w),?')
-deflist_macro_regex = re.compile('\dM\d+(\w)')
+deflist_regex = re.compile(rb'(\d*)(\w)(\d*)(\w),?')
+deflist_macro_regex = re.compile(r'\dM\d+(\w)')
 
 ##################################################################################
 

--- a/elixir/filters/projects.py
+++ b/elixir/filters/projects.py
@@ -20,7 +20,6 @@ from .makefiledir import MakefileDirFilter
 from .makefilesubdir import MakefileSubdirFilter
 from .makefilefile import MakefileFileFilter
 from .makefilesrctree import MakefileSrcTreeFilter
-from .makefilesubdir import MakefileSubdirFilter
 
 
 # List of filters applied to all projects

--- a/elixir/filters/utils.py
+++ b/elixir/filters/utils.py
@@ -5,7 +5,7 @@ from typing import Callable, List
 from ..query import Query
 
 # Context data used by Filters
-# tag: browsed version, unqoted
+# tag: browsed version, unquoted
 # family: family of file
 # path: path of file
 # get_ident_url: function that returns URL to identifier passed as argument

--- a/elixir/lib.py
+++ b/elixir/lib.py
@@ -28,14 +28,8 @@ CURRENT_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + '/../
 
 def script(*args, env=None):
     args = (os.path.join(CURRENT_DIR, 'script.sh'),) + args
-    # subprocess.run was introduced in Python 3.5
-    # fall back to subprocess.check_output if it's not available
-    if hasattr(subprocess, 'run'):
-        p = subprocess.run(args, stdout=subprocess.PIPE, env=env)
-        p = p.stdout
-    else:
-        p = subprocess.check_output(args)
-    return p
+    p = subprocess.run(args, stdout=subprocess.PIPE, env=env)
+    return p.stdout
 
 def run_cmd(*args, env=None):
     p = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)

--- a/elixir/query.py
+++ b/elixir/query.py
@@ -91,12 +91,12 @@ class Query:
         if version not in self.file_cache:
             version_cache = set()
             last_dir = None
-            for _, path in self.db.vers.get(version).iter():
-                dirname, filename = os.path.split(path)
+            for _, file_path in self.db.vers.get(version).iter():
+                dirname, filename = os.path.split(file_path)
                 if dirname != last_dir:
                     last_dir = dirname
                     version_cache.add(dirname)
-                version_cache.add(path)
+                version_cache.add(file_path)
 
             self.file_cache[version] = version_cache
 

--- a/elixir/query.py
+++ b/elixir/query.py
@@ -185,9 +185,9 @@ class Query:
 
     # Returns the latest tag that is included in the database.
     # This excludes release candidates if `rc` is False.
-    def get_latest_tag(self, rc):
+    def get_latest_tag(self, rc=False):
         if rc:
-            sorted_tags = reversed(self.scriptLines('list-tags'))
+            sorted_tags = list(reversed(self.scriptLines('list-tags')))
         else:
             sorted_tags = self.scriptLines('get-latest-tags')
 

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -211,6 +211,7 @@ class IndexResource:
                                      status=falcon.HTTP_INTERNAL_SERVER_ERROR)
 
         version = query.get_latest_tag()
+        query.close()
         resp.status = falcon.HTTP_FOUND
         resp.location = stringify_source_path(project, version, '/')
         return
@@ -367,6 +368,7 @@ class IncompleteURLRedirectResource:
             rc = version == 'latest-rc'
             version = query.get_latest_tag(rc=rc)
 
+        query.close()
         resp.status = falcon.HTTP_FOUND
         resp.location = stringify_source_path(project, version, '/')
 

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -157,7 +157,7 @@ def get_error_page(req, resp, exception: ElixirProjectError):
         'source_base_url': '/',
 
         'referer': req.referer,
-        'bug_report_url': ADD_ISSUE_LINK + parse.quote(report_error_details),
+        'bug_report_url': ADD_ISSUE_LINK + "?body=" + parse.quote(report_error_details),
         'report_error_details': report_error_details,
 
         'error_title': exception.title,

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -217,7 +217,7 @@ class IndexResource:
         return
 
 # Handles source URLs
-# Path parameters are asssumed to be unquoted by converters
+# Path parameters are assumed to be unquoted by converters
 class SourceResource:
     def on_get(self, req, resp, project: str, version: str, path: str):
         project, version, query = validate_project_and_version(req.context, project, version)
@@ -314,7 +314,7 @@ class IdentPostRedirectResource:
 
 # Handles ident URLs when family is specified in the URL, both POST and GET
 # See IdentPostRedirectResource for behavior on POST
-# Path parameters are asssumed to be unquoted by converters
+# Path parameters are assumed to be unquoted by converters
 class IdentResource(IdentPostRedirectResource):
     def on_get(self, req, resp, project: str, version: str, family: str, ident: str):
         project, version, query = validate_project_and_version(req.context, project, version)
@@ -429,8 +429,8 @@ def get_versions(versions: OrderedDict[str, OrderedDict[str, str]],
 
     result = OrderedDict()
     current_version_path = (None, None, None)
-    for major, minor_verions in versions.items():
-        for minor, patch_versions in minor_verions.items():
+    for major, minor_versions in versions.items():
+        for minor, patch_versions in minor_versions.items():
             for v in patch_versions:
                 if major not in result:
                     result[major] = OrderedDict()
@@ -456,7 +456,7 @@ def get_versions_cached(q, ctx, project):
 
         return cached_versions[1]
 
-# Retruns template context used by the layout template
+# Returns template context used by the layout template
 # get_url_with_new_version: see get_url parameter of get_versions
 # project: name of the project
 # version: version of the project
@@ -791,7 +791,7 @@ class RequestContextMiddleware:
             self.versions_cache_lock,
         )
 
-# Serialies caught exceptions to JSON or HTML
+# Serializes caught exceptions to JSON or HTML
 # See https://falcon.readthedocs.io/en/stable/api/app.html#falcon.App.set_error_serializer
 def error_serializer(req, resp, exception):
     preferred = req.client_prefers((falcon.MEDIA_HTML, falcon.MEDIA_JSON))

--- a/elixir/web.py
+++ b/elixir/web.py
@@ -561,7 +561,7 @@ def generate_source(q: Query, project: str, version: str, path: str) -> str:
     html_code_block = format_code(fname, code)
 
     # Replace line numbers by links to the corresponding line in the current file
-    html_code_block = sub('href="#codeline-(\d+)', 'name="L\\1" id="L\\1" href="#L\\1', html_code_block)
+    html_code_block = sub(r'href="#codeline-(\d+)', 'name="L\\1" id="L\\1" href="#L\\1', html_code_block)
 
     for f in filters:
         html_code_block = f.untransform_formatted_code(filter_ctx, html_code_block)

--- a/t/TestEnvironment.pm
+++ b/t/TestEnvironment.pm
@@ -96,13 +96,13 @@ has script_sh => (
     default => sub { find_program('script.sh') }
 );
 has query_py => (
-    default => sub { find_program('query.py') }
+    default => sub { find_program('elixir', 'query.py') }
 );
 has update_py => (
     default => sub { find_program('update.py') }
 );
 has web_py => (
-    default => sub { find_program(qw(http web.py)) }
+    default => sub { find_program('elixir', 'web.py') }
 );
 has find_doc => (
     default => sub { find_program('find-file-doc-comments.pl') }


### PR DESCRIPTION
- Fix query_py and web_py paths after elixir/ restructure
- Remove dead Python < 3.5 compatibility branch in script()
- Remove duplicate MakefileSubdirFilter import
- Fix typos in comments
- Use raw strings for regex patterns
- Fix query handle leak
- Fix crash on empty cursor result
- Fix malformed bug-report URL in get_error_page()
- Fix variable shadowing in file_exists()
- Fix get_latest_tag() missing default for r