### PR TITLE
update: skip None defs entries in generate_defs_caches()

### DIFF
--- a/update.py
+++ b/update.py
@@ -192,6 +192,8 @@ class UpdateVersions(Thread):
 def generate_defs_caches():
     for key in db.defs.get_keys():
         value = db.defs.get(key)
+        if value is None:
+            continue
         for family in ['C', 'K', 'D', 'M']:
             if (lib.compatibleFamily(value.get_families(), family) or
                         lib.compatibleMacro(value.get_macros(), family)):


### PR DESCRIPTION
db.defs.get() can return None when the database is in a bad state. Guard against it to avoid an AttributeError on value.get_families().