### PR TITLE
templates/topbar: remove whitespace from file path

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1067,12 +1067,12 @@ main {
   z-index: 2;
 }
 
-
 /* responsive */
 
 .open-menu {
   margin-right: 1.2rem;
   margin-left: -0.5rem;
+  user-select: none;
 }
 .open-menu::before {
   font-size: 1.5rem;

--- a/templates/topbar.html
+++ b/templates/topbar.html
@@ -1,11 +1,13 @@
 <header class="topbar">
     <div class="breadcrumb">
+        {#- This line removes leading whitespace from copied path -#}
         <a href="#menu" class="open-menu icon-menu screenreader" title="Open Menu">Open Menu</a>
+        {#- This line removes leading whitespace from copied path -#}
         <a class="project" href="{{ source_base_url }}">/</a>
-        {% for name, url in breadcrumb_urls %}
-            <a href="{{ url }}">{{ name }}</a>
-            {{ '/' if not loop.last else '' }}
-        {% endfor %}
+        {%- for name, url in breadcrumb_urls -%}
+            <a href="{{ url }}">{{- name -}}</a>
+            {{- '/' if not loop.last else '' -}}
+        {%- endfor -%}
     </div>
     <div class="search">
         <form method="GET" action="{{ ident_base_url }}" id="search-form">


### PR DESCRIPTION
Topbar path contains whitespace that is visible after selecting, copying and pasting the path. This commit removes the whitespace.

Closes: #434